### PR TITLE
refactor(frontend): inline styles to Tailwind, CSS layer fix, theme switch bug

### DIFF
--- a/apps/desktop/src-tauri/gen/schemas/macOS-schema.json
+++ b/apps/desktop/src-tauri/gen/schemas/macOS-schema.json
@@ -6171,6 +6171,204 @@
           "markdownDescription": "Denies the log command without any pre-configured scope."
         },
         {
+          "description": "This permission set configures which\nnotification features are by default exposed.\n\n#### Granted Permissions\n\nIt allows all notification related features.\n\n\n#### This default permission set includes:\n\n- `allow-is-permission-granted`\n- `allow-request-permission`\n- `allow-notify`\n- `allow-register-action-types`\n- `allow-register-listener`\n- `allow-cancel`\n- `allow-get-pending`\n- `allow-remove-active`\n- `allow-get-active`\n- `allow-check-permissions`\n- `allow-show`\n- `allow-batch`\n- `allow-list-channels`\n- `allow-delete-channel`\n- `allow-create-channel`\n- `allow-permission-state`",
+          "type": "string",
+          "const": "notification:default",
+          "markdownDescription": "This permission set configures which\nnotification features are by default exposed.\n\n#### Granted Permissions\n\nIt allows all notification related features.\n\n\n#### This default permission set includes:\n\n- `allow-is-permission-granted`\n- `allow-request-permission`\n- `allow-notify`\n- `allow-register-action-types`\n- `allow-register-listener`\n- `allow-cancel`\n- `allow-get-pending`\n- `allow-remove-active`\n- `allow-get-active`\n- `allow-check-permissions`\n- `allow-show`\n- `allow-batch`\n- `allow-list-channels`\n- `allow-delete-channel`\n- `allow-create-channel`\n- `allow-permission-state`"
+        },
+        {
+          "description": "Enables the batch command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-batch",
+          "markdownDescription": "Enables the batch command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the cancel command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-cancel",
+          "markdownDescription": "Enables the cancel command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the check_permissions command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-check-permissions",
+          "markdownDescription": "Enables the check_permissions command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the create_channel command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-create-channel",
+          "markdownDescription": "Enables the create_channel command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the delete_channel command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-delete-channel",
+          "markdownDescription": "Enables the delete_channel command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-get-active",
+          "markdownDescription": "Enables the get_active command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_pending command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-get-pending",
+          "markdownDescription": "Enables the get_pending command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the is_permission_granted command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-is-permission-granted",
+          "markdownDescription": "Enables the is_permission_granted command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the list_channels command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-list-channels",
+          "markdownDescription": "Enables the list_channels command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the notify command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-notify",
+          "markdownDescription": "Enables the notify command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the permission_state command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-permission-state",
+          "markdownDescription": "Enables the permission_state command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register_action_types command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-register-action-types",
+          "markdownDescription": "Enables the register_action_types command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-register-listener",
+          "markdownDescription": "Enables the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-remove-active",
+          "markdownDescription": "Enables the remove_active command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the request_permission command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-request-permission",
+          "markdownDescription": "Enables the request_permission command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:allow-show",
+          "markdownDescription": "Enables the show command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the batch command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-batch",
+          "markdownDescription": "Denies the batch command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cancel command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-cancel",
+          "markdownDescription": "Denies the cancel command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the check_permissions command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-check-permissions",
+          "markdownDescription": "Denies the check_permissions command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the create_channel command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-create-channel",
+          "markdownDescription": "Denies the create_channel command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the delete_channel command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-delete-channel",
+          "markdownDescription": "Denies the delete_channel command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-get-active",
+          "markdownDescription": "Denies the get_active command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_pending command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-get-pending",
+          "markdownDescription": "Denies the get_pending command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the is_permission_granted command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-is-permission-granted",
+          "markdownDescription": "Denies the is_permission_granted command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the list_channels command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-list-channels",
+          "markdownDescription": "Denies the list_channels command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the notify command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-notify",
+          "markdownDescription": "Denies the notify command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the permission_state command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-permission-state",
+          "markdownDescription": "Denies the permission_state command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register_action_types command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-register-action-types",
+          "markdownDescription": "Denies the register_action_types command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-register-listener",
+          "markdownDescription": "Denies the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-remove-active",
+          "markdownDescription": "Denies the remove_active command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the request_permission command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-request-permission",
+          "markdownDescription": "Denies the request_permission command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "const": "notification:deny-show",
+          "markdownDescription": "Denies the show command without any pre-configured scope."
+        },
+        {
           "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`",
           "type": "string",
           "const": "shell:default",

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -43,6 +43,7 @@ export default [
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-empty-object-type': 'off',
+      'no-console': 'warn',
     },
   },
 ];

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,6 +50,7 @@ import { initConnection } from '@/lib/backend/httpEvents';
 import { setupMainWindowCloseHandler } from '@/lib/chatWindow';
 import { CHAT_OVERLAY_SYNC_EVENT, CHAT_OVERLAY_SYNC_REQUEST_EVENT } from '@/lib/chatEvents';
 import { useChatStore } from '@/stores/chatStore';
+import { logger } from '@/lib/logger';
 
 // Import all views
 import {
@@ -131,7 +132,7 @@ function MainApp() {
       if (!event.data || event.data.type !== 'chat-overlay-sync-request') return;
       const messages = useChatStore.getState().messages;
       const target = event.source as Window | null;
-      target?.postMessage({ type: 'chat-overlay-sync', messages }, { targetOrigin: '*' });
+      target?.postMessage({ type: 'chat-overlay-sync', messages }, { targetOrigin: window.location.origin });
     };
 
     window.addEventListener('message', handleMessage);
@@ -145,7 +146,7 @@ function MainApp() {
     listen(CHAT_OVERLAY_SYNC_REQUEST_EVENT, () => {
       const messages = useChatStore.getState().messages;
       emit(CHAT_OVERLAY_SYNC_EVENT, { messages }).catch((error) => {
-        console.error('Failed to sync chat overlay:', error);
+        logger.error('Failed to sync chat overlay:', error);
       });
     }).then((unsubscribe) => {
       unlisten = unsubscribe;
@@ -274,8 +275,8 @@ function MainApp() {
   // Show loading state while checking server health
   if (serverStatus === 'checking') {
     return (
-      <div className="fixed inset-0 flex items-center justify-center bg-[var(--bg-base)]">
-        <div className="text-[var(--text-secondary)]">{t('common.loading', { defaultValue: 'Loading...' })}</div>
+      <div className="fixed inset-0 flex items-center justify-center bg-bg-base">
+        <div className="text-text-secondary">{t('common.loading', { defaultValue: 'Loading...' })}</div>
       </div>
     );
   }
@@ -323,7 +324,7 @@ function AppContent() {
   }, []);
 
   // Store hooks
-  const { setLanguage } = useLanguageStore();
+  const { initFromSettings: setLanguageFromProfile } = useLanguageStore();
   const { currentThemeId, setTheme } = useThemeStore();
 
   const [currentView, setCurrentView] = useState<View>('dashboard');
@@ -351,15 +352,15 @@ function AppContent() {
 
         // Apply language (profile-specific)
         if (current.settings.language) {
-          setLanguage(current.settings.language as any);
+          setLanguageFromProfile(current.settings.language);
         }
       } catch (error) {
-        console.error('Failed to apply profile settings:', error);
+        logger.error('Failed to apply profile settings:', error);
       }
     };
 
     applyProfileSettings();
-  }, [current, currentThemeId, setTheme, setLanguage]);
+  }, [current, currentThemeId, setTheme, setLanguageFromProfile]);
 
   // Modal state
   const [profileModalOpen, setProfileModalOpen] = useState(false);
@@ -436,7 +437,7 @@ function AppContent() {
       await startAllGroups(current.outputGroups, incomingUrl);
       toast.success(t('toast.streamStarted'));
     } catch (err) {
-      console.error('[App] startAllGroups failed:', err);
+      logger.error('[App] startAllGroups failed:', err);
       toast.error(
         t('toast.startFailed', {
           error: err instanceof Error ? err.message : String(err),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -325,7 +325,7 @@ function AppContent() {
 
   // Store hooks
   const { initFromSettings: setLanguageFromProfile } = useLanguageStore();
-  const { currentThemeId, setTheme } = useThemeStore();
+  const { setTheme } = useThemeStore();
 
   const [currentView, setCurrentView] = useState<View>('dashboard');
   const {
@@ -339,6 +339,10 @@ function AppContent() {
   const { isStreaming, startAllGroups, stopAllGroups } = useStreamStore();
 
   // Apply profile-specific theme and language when profile changes
+  // NOTE: currentThemeId is intentionally NOT in deps — this effect should only
+  // fire when the profile changes, not when the user switches themes via Settings.
+  // Including it caused a snap-back loop: theme change → effect sees stale profile
+  // themeId → resets theme → profile updates → effect fires again.
   useEffect(() => {
     const applyProfileSettings = async () => {
       if (!current?.settings) return;
@@ -346,7 +350,8 @@ function AppContent() {
       try {
         // Apply theme (profile-specific)
         const themeId = current.settings.themeId;
-        if (themeId && themeId !== currentThemeId) {
+        const activeThemeId = useThemeStore.getState().currentThemeId;
+        if (themeId && themeId !== activeThemeId) {
           await setTheme(themeId);
         }
 
@@ -360,7 +365,8 @@ function AppContent() {
     };
 
     applyProfileSettings();
-  }, [current, currentThemeId, setTheme, setLanguageFromProfile]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [current, setTheme, setLanguageFromProfile]);
 
   // Modal state
   const [profileModalOpen, setProfileModalOpen] = useState(false);

--- a/apps/web/src/components/chat/ChatList.tsx
+++ b/apps/web/src/components/chat/ChatList.tsx
@@ -74,8 +74,7 @@ export function ChatList({
       {messages.length === 0 ? (
         showEmptyState ? (
           <div
-            className="text-center text-[var(--text-tertiary)]"
-            style={{ padding: '40px 16px' }}
+            className="text-center text-text-tertiary py-10 px-4"
           >
             {emptyLabel}
           </div>
@@ -101,8 +100,8 @@ export function ChatList({
                 className={cn(
                   'flex items-start gap-3 rounded-lg border p-3',
                   isOutbound
-                    ? 'border-[var(--border-strong)] bg-[var(--bg-base)]'
-                    : 'border-[var(--border-subtle)] bg-[var(--bg-elevated)]'
+                    ? 'border-border-strong bg-bg-base'
+                    : 'border-border-subtle bg-bg-elevated'
                 )}
               >
                 <div className="flex items-center gap-1">
@@ -111,15 +110,15 @@ export function ChatList({
                   ))}
                 </div>
                 <div className={cn('flex flex-wrap items-baseline gap-x-2 gap-y-1', densityConfig.text)}>
-                  <span className="font-semibold text-[var(--text-primary)]">
+                  <span className="font-semibold text-text-primary">
                     {isOutbound ? t('chat.you') : message.username}
                   </span>
                   {timestamp && (
-                    <span className="text-[0.7rem] text-[var(--text-tertiary)]">
+                    <span className="text-[0.7rem] text-text-tertiary">
                       {timestamp}
                     </span>
                   )}
-                  <span className="text-[var(--text-secondary)] break-words">{message.message}</span>
+                  <span className="text-text-secondary break-words">{message.message}</span>
                 </div>
               </div>
             );

--- a/apps/web/src/components/dashboard/ProfileCard.tsx
+++ b/apps/web/src/components/dashboard/ProfileCard.tsx
@@ -35,24 +35,24 @@ export function ProfileCard({
     <div
       onClick={onClick}
       className={cn(
-        'bg-[var(--bg-surface)] border-2 rounded-xl h-full',
+        'bg-bg-surface border-2 rounded-xl h-full',
         'transition-all duration-150',
         onClick && 'cursor-pointer',
         active
-          ? 'border-[var(--primary)] bg-[var(--primary-muted)]'
-          : 'border-[var(--border-default)] hover:border-[var(--border-interactive)] hover:-translate-y-0.5 hover:shadow-[var(--shadow-md)]',
+          ? 'border-primary bg-primary-muted'
+          : 'border-border-default hover:border-border-interactive hover:-translate-y-0.5 hover:shadow-md',
+        'p-5',
         className
       )}
-      style={{ padding: '20px' }}
     >
       <div className="flex items-center justify-between mb-3">
-        <span className="font-semibold text-[var(--text-primary)]">{name}</span>
+        <span className="font-semibold text-text-primary">{name}</span>
         <div className="flex items-center gap-2">
           {active && <StreamStatus status="live" label={t('dashboard.active')} />}
           {actions}
         </div>
       </div>
-      <div className="flex gap-4 text-small text-[var(--text-secondary)]">
+      <div className="flex gap-4 text-small text-text-secondary">
         {meta.map((item, index) => (
           <span key={index} className="flex items-center gap-1.5">
             {item.icon}
@@ -62,7 +62,7 @@ export function ProfileCard({
       </div>
       {/* Service icons showing which platforms this profile targets (Story 1.1, 4.1, 4.2) */}
       {services && services.length > 0 && (
-        <div className="flex gap-1.5 mt-3 pt-3 border-t border-[var(--border-muted)]">
+        <div className="flex gap-1.5 mt-3 pt-3 border-t border-border-muted">
           {services.map((service) => (
             <PlatformIcon key={service} platform={service} size="sm" />
           ))}

--- a/apps/web/src/components/dashboard/StatBox.tsx
+++ b/apps/web/src/components/dashboard/StatBox.tsx
@@ -20,22 +20,22 @@ export function StatBox({
   return (
     <div
       className={cn(
-        'bg-[var(--bg-surface)] border border-[var(--border-default)]',
+        'bg-bg-surface border border-border-default',
         'rounded-xl',
+        'p-5',
         className
       )}
-      style={{ padding: '20px' }}
     >
       <div className="flex items-center justify-between mb-2">
-        <span className="text-small text-[var(--text-secondary)]">{label}</span>
-        <span className="text-[var(--text-tertiary)]">{icon}</span>
+        <span className="text-small text-text-secondary">{label}</span>
+        <span className="text-text-tertiary">{icon}</span>
       </div>
-      <div className="text-2xl font-bold text-[var(--text-primary)]">{value}</div>
+      <div className="text-2xl font-bold text-text-primary">{value}</div>
       {change && (
         <div
           className={cn(
             'text-xs mt-1',
-            changeType === 'positive' ? 'text-[var(--success-text)]' : 'text-[var(--text-tertiary)]'
+            changeType === 'positive' ? 'text-success-text' : 'text-text-tertiary'
           )}
         >
           {change}

--- a/apps/web/src/components/dashboard/StatsRow.tsx
+++ b/apps/web/src/components/dashboard/StatsRow.tsx
@@ -8,8 +8,7 @@ export interface StatsRowProps {
 export function StatsRow({ children, className }: StatsRowProps) {
   return (
     <div
-      className={cn('grid grid-cols-4', 'max-xl:grid-cols-2 max-md:grid-cols-1', className)}
-      style={{ gap: '16px', marginBottom: '24px' }}
+      className={cn('grid grid-cols-4 gap-4 mb-6', 'max-xl:grid-cols-2 max-md:grid-cols-1', className)}
     >
       {children}
     </div>

--- a/apps/web/src/components/dashboard/StreamCard.tsx
+++ b/apps/web/src/components/dashboard/StreamCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { cn } from '@/lib/cn';
 import { StreamStatus } from '@/components/ui/StreamStatus';
 import { PlatformIcon } from '@/components/stream/PlatformIcon';
@@ -18,36 +19,36 @@ export interface StreamCardProps {
   className?: string;
 }
 
-export function StreamCard({ platform, name, status, stats, onClick, className }: StreamCardProps) {
+export const StreamCard = memo(function StreamCard({ platform, name, status, stats, onClick, className }: StreamCardProps) {
   return (
     <div
       onClick={onClick}
       className={cn(
-        'bg-[var(--bg-surface)] border border-[var(--border-default)]',
+        'bg-bg-surface border border-border-default',
         'rounded-xl transition-all duration-150',
-        'hover:border-[var(--border-interactive)] hover:shadow-[var(--shadow-md)]',
+        'hover:border-border-interactive hover:shadow-md',
         onClick && 'cursor-pointer',
+        'p-4',
         className
       )}
-      style={{ padding: '16px' }}
     >
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <PlatformIcon platform={platform} />
-          <span className="font-semibold text-sm text-[var(--text-primary)]">{name}</span>
+          <span className="font-semibold text-sm text-text-primary">{name}</span>
         </div>
         <StreamStatus status={status} />
       </div>
       {stats && stats.length > 0 && (
-        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-[var(--border-muted)]">
+        <div className="grid grid-cols-3 gap-3 pt-3 border-t border-border-muted">
           {stats.map((stat, index) => (
             <div key={index} className="text-center">
-              <div className="text-sm font-semibold text-[var(--text-primary)]">{stat.value}</div>
-              <div className="text-tiny uppercase text-[var(--text-tertiary)]">{stat.label}</div>
+              <div className="text-sm font-semibold text-text-primary">{stat.value}</div>
+              <div className="text-tiny uppercase text-text-tertiary">{stat.label}</div>
             </div>
           ))}
         </div>
       )}
     </div>
   );
-}
+});

--- a/apps/web/src/components/encoder/EncoderCard.tsx
+++ b/apps/web/src/components/encoder/EncoderCard.tsx
@@ -136,34 +136,34 @@ export function EncoderCard({
     <Card className={cn('transition-all duration-150', className)}>
       <CardBody>
         {/* Header Row */}
-        <div className="flex items-start justify-between" style={{ marginBottom: '16px' }}>
-          <div className="flex items-center" style={{ gap: '12px' }}>
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
             {/* Encoder Icon */}
             <div
               className={cn(
                 'w-10 h-10 rounded-lg flex items-center justify-center',
                 encoder.type === 'passthrough'
-                  ? 'bg-[var(--bg-muted)] text-[var(--text-secondary)]'
+                  ? 'bg-bg-muted text-text-secondary'
                   : encoder.type === 'hardware'
-                    ? 'bg-[var(--success-subtle)] text-[var(--success-text)]'
-                    : 'bg-[var(--primary-subtle)] text-[var(--primary)]'
+                    ? 'bg-success-subtle text-success-text'
+                    : 'bg-primary-subtle text-primary'
               )}
             >
               <Cpu className="w-5 h-5" />
             </div>
             <div>
-              <h3 className="font-semibold text-[var(--text-primary)]">
+              <h3 className="font-semibold text-text-primary">
                 {group.name || tDynamic('encoder.defaultEncoderName', { defaultValue: 'Encoder' })}
                 {isDefaultGroup && (
-                  <span className="ml-2 text-xs font-normal text-[var(--text-tertiary)]">
+                  <span className="ml-2 text-xs font-normal text-text-tertiary">
                     ({tDynamic('encoder.readonly', { defaultValue: 'Read-only' })})
                   </span>
                 )}
               </h3>
-              <p className="text-sm text-[var(--text-secondary)]">
+              <p className="text-sm text-text-secondary">
                 {encoder.label}
                 {encoder.type !== 'passthrough' && (
-                  <span className="text-[var(--text-tertiary)]">
+                  <span className="text-text-tertiary">
                     {' '}
                     ({encoder.type === 'hardware'
                       ? tDynamic('encoder.hardware', { defaultValue: 'Hardware' })
@@ -173,65 +173,64 @@ export function EncoderCard({
               </p>
             </div>
           </div>
-          <div className="flex items-center" style={{ gap: '8px' }}>
+          <div className="flex items-center gap-2">
             <StreamStatus status={status} />
           </div>
         </div>
 
         {/* Video Settings Grid */}
         <div
-          className="grid gap-4 py-4 border-t border-b border-[var(--border-muted)]"
-          style={{ gridTemplateColumns: 'repeat(4, 1fr)' }}
+          className="grid grid-cols-4 gap-4 py-4 border-t border-b border-border-muted"
         >
           <div className="flex flex-col items-center text-center">
-            <Monitor className="w-4 h-4 text-[var(--text-tertiary)]" style={{ marginBottom: '4px' }} />
-            <span className="text-xs text-[var(--text-tertiary)] uppercase">
+            <Monitor className="w-4 h-4 text-text-tertiary mb-1" />
+            <span className="text-xs text-text-tertiary uppercase">
               {tDynamic('encoder.resolution', { defaultValue: 'Resolution' })}
             </span>
-            <span className="text-sm font-medium text-[var(--text-primary)]">{resolution}</span>
+            <span className="text-sm font-medium text-text-primary">{resolution}</span>
           </div>
           <div className="flex flex-col items-center text-center">
-            <Gauge className="w-4 h-4 text-[var(--text-tertiary)]" style={{ marginBottom: '4px' }} />
-            <span className="text-xs text-[var(--text-tertiary)] uppercase">
+            <Gauge className="w-4 h-4 text-text-tertiary mb-1" />
+            <span className="text-xs text-text-tertiary uppercase">
               {tDynamic('encoder.bitrate', { defaultValue: 'Bitrate' })}
             </span>
-            <span className="text-sm font-medium text-[var(--text-primary)]">{bitrate}</span>
+            <span className="text-sm font-medium text-text-primary">{bitrate}</span>
           </div>
           <div className="flex flex-col items-center text-center">
-            <Film className="w-4 h-4 text-[var(--text-tertiary)]" style={{ marginBottom: '4px' }} />
-            <span className="text-xs text-[var(--text-tertiary)] uppercase">
+            <Film className="w-4 h-4 text-text-tertiary mb-1" />
+            <span className="text-xs text-text-tertiary uppercase">
               {tDynamic('encoder.fps', { defaultValue: 'FPS' })}
             </span>
-            <span className="text-sm font-medium text-[var(--text-primary)]">{fps}</span>
+            <span className="text-sm font-medium text-text-primary">{fps}</span>
           </div>
           <div className="flex flex-col items-center text-center">
-            <Settings2 className="w-4 h-4 text-[var(--text-tertiary)]" style={{ marginBottom: '4px' }} />
-            <span className="text-xs text-[var(--text-tertiary)] uppercase">
+            <Settings2 className="w-4 h-4 text-text-tertiary mb-1" />
+            <span className="text-xs text-text-tertiary uppercase">
               {tDynamic('encoder.preset', { defaultValue: 'Preset' })}
             </span>
-            <span className="text-sm font-medium text-[var(--text-primary)]">{preset}</span>
+            <span className="text-sm font-medium text-text-primary">{preset}</span>
           </div>
         </div>
 
         {/* Footer: Audio + Actions */}
-        <div className="flex items-center justify-between" style={{ marginTop: '12px' }}>
-          <div className="flex items-center text-sm" style={{ gap: '8px' }}>
-            <Volume2 className="w-4 h-4 text-[var(--secondary)]" />
-            <span className="text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between mt-3">
+          <div className="flex items-center text-sm gap-2">
+            <Volume2 className="w-4 h-4 text-secondary" />
+            <span className="text-text-secondary">
               {tDynamic('encoder.audio', { defaultValue: 'Audio' })}:
             </span>
-            <span className="text-[var(--text-primary)]">{audioSummary}</span>
+            <span className="text-text-primary">{audioSummary}</span>
             {group.video.profile && (
               <>
-                <span className="text-[var(--text-tertiary)]">|</span>
-                <span className="text-[var(--text-secondary)]">
+                <span className="text-text-tertiary">|</span>
+                <span className="text-text-secondary">
                   {tDynamic('encoder.profile', { defaultValue: 'Profile' })}:
                 </span>
-                <span className="text-[var(--text-primary)]">{profile}</span>
+                <span className="text-text-primary">{profile}</span>
               </>
             )}
           </div>
-          <div className="flex items-center" style={{ gap: '4px' }}>
+          <div className="flex items-center gap-1">
             {!isDefaultGroup && onEdit && (
               <>
                 <Button
@@ -261,7 +260,7 @@ export function EncoderCard({
               </>
             )}
             {isDefaultGroup && (
-              <span className="text-xs text-[var(--text-tertiary)] italic px-2">
+              <span className="text-xs text-text-tertiary italic px-2">
                 {tDynamic('encoder.defaultPassthrough', { defaultValue: 'Default RTMP relay - cannot be edited or deleted' })}
               </span>
             )}

--- a/apps/web/src/components/feedback/LogConsole.tsx
+++ b/apps/web/src/components/feedback/LogConsole.tsx
@@ -10,7 +10,7 @@ export function LogConsole({ children, maxHeight = '300px', className }: LogCons
   return (
     <div
       className={cn(
-        'bg-[var(--bg-sunken)] border border-[var(--border-default)] rounded-lg',
+        'bg-bg-sunken border border-border-default rounded-lg',
         "font-['JetBrains_Mono',monospace] text-xs overflow-y-auto",
         className
       )}

--- a/apps/web/src/components/feedback/LogEntry.tsx
+++ b/apps/web/src/components/feedback/LogEntry.tsx
@@ -9,10 +9,10 @@ export interface LogEntryProps {
 }
 
 const levelStyles: Record<LogLevel, string> = {
-  info: 'text-[var(--primary)]',
-  warn: 'text-[var(--warning-text)]',
-  error: 'text-[var(--error-text)]',
-  debug: 'text-[var(--text-tertiary)]',
+  info: 'text-primary',
+  warn: 'text-warning-text',
+  error: 'text-error-text',
+  debug: 'text-text-tertiary',
 };
 
 export function LogEntry({ time, level, message }: LogEntryProps) {
@@ -26,12 +26,11 @@ export function LogEntry({ time, level, message }: LogEntryProps) {
 
   return (
     <div
-      className="flex border-b border-[var(--border-muted)] last:border-b-0"
-      style={{ padding: '6px 12px', gap: '12px' }}
+      className="flex border-b border-border-muted last:border-b-0 py-1.5 px-3 gap-3"
     >
-      <span className="text-[var(--text-muted)] whitespace-nowrap">{time}</span>
+      <span className="text-text-muted whitespace-nowrap">{time}</span>
       <span className={cn('font-semibold w-12', levelStyles[level])}>{levelLabels[level]}</span>
-      <span className="text-[var(--text-primary)] break-words flex-1">{message}</span>
+      <span className="text-text-primary break-words flex-1">{message}</span>
     </div>
   );
 }

--- a/apps/web/src/components/integrations/ChatPanel.tsx
+++ b/apps/web/src/components/integrations/ChatPanel.tsx
@@ -20,9 +20,11 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Toggle } from '@/components/ui/Toggle';
 import { api, events } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import { toast } from '@/hooks/useToast';
 import { cn } from '@/lib/cn';
 import { useProfileStore } from '@/stores/profileStore';
+import { CHAT_POLL_INTERVAL_MS } from '@/lib/constants';
 import type { ChatPlatform, ChatPlatformStatus, OAuthAccount } from '@/types/chat';
 import type { ChatSettings } from '@/types/profile';
 import { createDefaultChatSettings } from '@/types/profile';
@@ -155,22 +157,22 @@ function TwitchCard({
           {/* Connection status indicator */}
           <div className="flex items-center gap-2">
             {isConnecting ? (
-              <Loader2 className="w-4 h-4 text-[var(--status-connecting)] animate-spin" />
+              <Loader2 className="w-4 h-4 text-status-connecting animate-spin" />
             ) : isConnected ? (
-              <Wifi className="w-4 h-4 text-[var(--status-live)]" />
+              <Wifi className="w-4 h-4 text-status-live" />
             ) : hasError ? (
-              <AlertCircle className="w-4 h-4 text-[var(--status-error)]" />
+              <AlertCircle className="w-4 h-4 text-status-error" />
             ) : (
-              <WifiOff className="w-4 h-4 text-[var(--text-tertiary)]" />
+              <WifiOff className="w-4 h-4 text-text-tertiary" />
             )}
             <span
               className={cn(
                 'text-sm',
                 isConnected
-                  ? 'text-[var(--status-live)]'
+                  ? 'text-status-live'
                   : hasError
-                    ? 'text-[var(--status-error)]'
-                    : 'text-[var(--text-tertiary)]'
+                    ? 'text-status-error'
+                    : 'text-text-tertiary'
               )}
             >
               {statusLabel}
@@ -180,19 +182,19 @@ function TwitchCard({
       </CardHeader>
       <CardBody className="space-y-4">
         {/* Account section */}
-        <div className="p-3 rounded-lg bg-[var(--bg-elevated)] border border-[var(--border-subtle)]">
+        <div className="p-3 rounded-lg bg-bg-elevated border border-border-subtle">
           <div className="flex items-center gap-3">
-            <div className="p-2 rounded-full bg-[var(--bg-base)]">
-              <User className="w-5 h-5 text-[var(--text-secondary)]" />
+            <div className="p-2 rounded-full bg-bg-base">
+              <User className="w-5 h-5 text-text-secondary" />
             </div>
             <div className="flex-1">
               {isLoggedIn ? (
                 <>
-                  <p className="font-medium text-[var(--text-primary)]">{account?.displayName}</p>
-                  <p className="text-sm text-[var(--text-secondary)]">@{account?.username}</p>
+                  <p className="font-medium text-text-primary">{account?.displayName}</p>
+                  <p className="text-sm text-text-secondary">@{account?.username}</p>
                 </>
               ) : (
-                <p className="text-[var(--text-secondary)]">{t('chat.notLoggedIn', 'Not logged in')}</p>
+                <p className="text-text-secondary">{t('chat.notLoggedIn', 'Not logged in')}</p>
               )}
             </div>
             <div className="flex gap-2">
@@ -213,7 +215,7 @@ function TwitchCard({
                     onClick={handleForget}
                     disabled={isLoggingOut}
                     title={t('chat.forgetAccount', 'Forget Account')}
-                    className="text-[var(--status-error)] hover:text-[var(--status-error)]"
+                    className="text-status-error hover:text-status-error"
                   >
                     <Trash2 className="w-4 h-4" />
                   </Button>
@@ -242,7 +244,7 @@ function TwitchCard({
           disabled={isConnected || isConnecting}
         />
         {!isLoggedIn && (
-          <p className="text-xs text-[var(--text-tertiary)]">
+          <p className="text-xs text-text-tertiary">
             {t('chat.twitch.readOnlyHint', 'Read-only without login')}
           </p>
         )}
@@ -255,29 +257,29 @@ function TwitchCard({
           className="pt-1"
         />
         {!isLoggedIn && (
-          <p className="text-xs text-[var(--text-tertiary)]">
+          <p className="text-xs text-text-tertiary">
             {t('chat.sendRequiresLogin', 'Sign in to send messages')}
           </p>
         )}
 
         {/* Error message */}
         {hasError && status?.error && (
-          <div className="flex items-start gap-2 p-3 rounded-lg bg-[var(--status-error)]/10 border border-[var(--status-error)]/20">
-            <AlertCircle className="w-4 h-4 text-[var(--status-error)] flex-shrink-0 mt-0.5" />
-            <p className="text-sm text-[var(--status-error)]">{status.error}</p>
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-status-error/10 border border-status-error/20">
+            <AlertCircle className="w-4 h-4 text-status-error flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-status-error">{status.error}</p>
           </div>
         )}
 
         {/* Message count */}
         {isConnected && status && (
-          <div className="text-sm text-[var(--text-secondary)]">
+          <div className="text-sm text-text-secondary">
             {t('chat.messageCount', { count: status.messageCount })}
           </div>
         )}
 
         {/* Stream-tied lifecycle hint + retry/clear */}
         <div className="flex items-center justify-between pt-2">
-          <p className="text-xs text-[var(--text-tertiary)]">
+          <p className="text-xs text-text-tertiary">
             {t(
               'chat.streamTiedHint',
               'Chat connects when you start streaming. YouTube may take ~10s to activate.'
@@ -412,22 +414,22 @@ function YouTubeCard({
           {/* Connection status indicator */}
           <div className="flex items-center gap-2">
             {isConnecting ? (
-              <Loader2 className="w-4 h-4 text-[var(--status-connecting)] animate-spin" />
+              <Loader2 className="w-4 h-4 text-status-connecting animate-spin" />
             ) : isConnected ? (
-              <Wifi className="w-4 h-4 text-[var(--status-live)]" />
+              <Wifi className="w-4 h-4 text-status-live" />
             ) : hasError ? (
-              <AlertCircle className="w-4 h-4 text-[var(--status-error)]" />
+              <AlertCircle className="w-4 h-4 text-status-error" />
             ) : (
-              <WifiOff className="w-4 h-4 text-[var(--text-tertiary)]" />
+              <WifiOff className="w-4 h-4 text-text-tertiary" />
             )}
             <span
               className={cn(
                 'text-sm',
                 isConnected
-                  ? 'text-[var(--status-live)]'
+                  ? 'text-status-live'
                   : hasError
-                    ? 'text-[var(--status-error)]'
-                    : 'text-[var(--text-tertiary)]'
+                    ? 'text-status-error'
+                    : 'text-text-tertiary'
               )}
             >
               {statusLabel}
@@ -439,7 +441,7 @@ function YouTubeCard({
         {/* Auth mode selector */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <label className="text-sm font-medium text-[var(--text-primary)]">
+            <label className="text-sm font-medium text-text-primary">
               {t('chat.youtube.authMethod', 'Authentication Method')}
             </label>
             <Button
@@ -451,11 +453,11 @@ function YouTubeCard({
               {showAdvanced ? t('chat.advancedHide', 'Hide advanced') : t('chat.advancedShow', 'Advanced')}
             </Button>
           </div>
-          <div className="p-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)]">
-            <p className="font-medium text-[var(--text-primary)]">
+          <div className="p-3 rounded-lg border border-border-subtle bg-bg-elevated">
+            <p className="font-medium text-text-primary">
               {t('chat.youtube.useOAuth', 'Sign in with Google')}
             </p>
-            <p className="text-xs text-[var(--text-tertiary)]">
+            <p className="text-xs text-text-tertiary">
               {t('chat.youtube.oauthHint', 'Uses shared app quota')}
             </p>
           </div>
@@ -472,19 +474,19 @@ function YouTubeCard({
 
         {/* OAuth account section (when OAuth mode is selected) */}
         {!useApiKey && (
-          <div className="p-3 rounded-lg bg-[var(--bg-elevated)] border border-[var(--border-subtle)]">
+          <div className="p-3 rounded-lg bg-bg-elevated border border-border-subtle">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-full bg-[var(--bg-base)]">
-                <User className="w-5 h-5 text-[var(--text-secondary)]" />
+              <div className="p-2 rounded-full bg-bg-base">
+                <User className="w-5 h-5 text-text-secondary" />
               </div>
               <div className="flex-1">
                 {isLoggedIn ? (
                   <>
-                    <p className="font-medium text-[var(--text-primary)]">{account?.displayName}</p>
-                    <p className="text-sm text-[var(--text-secondary)]">{account?.userId}</p>
+                    <p className="font-medium text-text-primary">{account?.displayName}</p>
+                    <p className="text-sm text-text-secondary">{account?.userId}</p>
                   </>
                 ) : (
-                  <p className="text-[var(--text-secondary)]">{t('chat.notLoggedIn', 'Not logged in')}</p>
+                  <p className="text-text-secondary">{t('chat.notLoggedIn', 'Not logged in')}</p>
                 )}
               </div>
               {isLoggedIn ? (
@@ -504,7 +506,7 @@ function YouTubeCard({
                     onClick={handleForget}
                     disabled={isLoggingOut}
                     title={t('chat.forgetAccount', 'Forget Account')}
-                    className="text-[var(--status-error)] hover:text-[var(--status-error)]"
+                    className="text-status-error hover:text-status-error"
                   >
                     <Trash2 className="w-4 h-4" />
                   </Button>
@@ -521,7 +523,7 @@ function YouTubeCard({
               )}
             </div>
             {!isLoggedIn && (
-              <p className="mt-2 text-xs text-[var(--text-tertiary)]">
+              <p className="mt-2 text-xs text-text-tertiary">
                 {t('chat.youtube.loginRequired', 'Sign in is required to read YouTube chat')}
               </p>
             )}
@@ -539,7 +541,7 @@ function YouTubeCard({
             disabled={isConnected || isConnecting}
           />
           <div className="flex items-center justify-between mt-1">
-            <p className="text-xs text-[var(--text-tertiary)]">
+            <p className="text-xs text-text-tertiary">
               {t('chat.youtube.channelIdHint', 'Use your YouTube channel ID')}
             </p>
             {!useApiKey && isLoggedIn && account?.userId && (
@@ -568,7 +570,7 @@ function YouTubeCard({
               className={cn(
                 'absolute right-3 top-[34px]',
                 'p-1 rounded-md',
-                'text-[var(--text-tertiary)] hover:text-[var(--text-primary)]',
+                'text-text-tertiary hover:text-text-primary',
                 'transition-colors'
               )}
             >
@@ -584,7 +586,7 @@ function YouTubeCard({
           description={t('chat.sendEnabledHint', 'Send messages from SpiritStream')}
         />
         {!canSend && (
-          <p className="text-xs text-[var(--text-tertiary)]">
+          <p className="text-xs text-text-tertiary">
             {useApiKey
               ? t('chat.youtube.apiKeyReadOnly', 'API keys are read-only')
               : t('chat.sendRequiresLogin', 'Sign in to send messages')}
@@ -593,22 +595,22 @@ function YouTubeCard({
 
         {/* Error message */}
         {hasError && status?.error && (
-          <div className="flex items-start gap-2 p-3 rounded-lg bg-[var(--status-error)]/10 border border-[var(--status-error)]/20">
-            <AlertCircle className="w-4 h-4 text-[var(--status-error)] flex-shrink-0 mt-0.5" />
-            <p className="text-sm text-[var(--status-error)]">{status.error}</p>
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-status-error/10 border border-status-error/20">
+            <AlertCircle className="w-4 h-4 text-status-error flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-status-error">{status.error}</p>
           </div>
         )}
 
         {/* Message count */}
         {isConnected && status && (
-          <div className="text-sm text-[var(--text-secondary)]">
+          <div className="text-sm text-text-secondary">
             {t('chat.messageCount', { count: status.messageCount })}
           </div>
         )}
 
         {/* Stream-tied lifecycle hint + retry/clear */}
         <div className="flex items-center justify-between pt-2">
-          <p className="text-xs text-[var(--text-tertiary)]">
+          <p className="text-xs text-text-tertiary">
             {t(
               'chat.streamTiedHint',
               'Chat connects when you start streaming. YouTube may take ~10s to activate.'
@@ -729,7 +731,7 @@ export function ChatPanel() {
         setTwitchAccount(twitchAcc);
         setYoutubeAccount(youtubeAcc);
       } catch (error) {
-        console.error('Failed to load chat settings:', error);
+        logger.error('Failed to load chat settings:', error);
       }
     };
 
@@ -765,7 +767,7 @@ export function ChatPanel() {
         const nextChat = { ...currentProfile.settings.chat, ...updates };
         await updateProfileSettings({ chat: nextChat });
       } catch (error) {
-        console.error('Failed to save chat settings:', error);
+        logger.error('Failed to save chat settings:', error);
       }
     },
     [currentProfile, updateProfileSettings]
@@ -798,9 +800,9 @@ export function ChatPanel() {
         const statuses = await api.chat.getStatus();
         setPlatformStatuses(statuses);
       } catch (error) {
-        console.error('Failed to load chat status:', error);
+        logger.error('Failed to load chat status:', error);
       }
-    }, 5000);
+    }, CHAT_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
   }, []);
@@ -1180,7 +1182,7 @@ export function ChatPanel() {
 
   if (!currentProfile) {
     return (
-      <div className="flex items-center justify-center p-8 text-[var(--text-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-text-tertiary">
         {t('common.loadProfileFirst', 'Please load a profile first')}
       </div>
     );
@@ -1190,16 +1192,16 @@ export function ChatPanel() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-[var(--bg-elevated)]">
-          <MessageSquare className="w-5 h-5 text-[var(--primary)]" />
+        <div className="p-2 rounded-lg bg-bg-elevated">
+          <MessageSquare className="w-5 h-5 text-primary" />
         </div>
         <div>
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t('chat.title')}</h2>
-          <p className="text-sm text-[var(--text-secondary)]">{t('chat.description')}</p>
+          <h2 className="text-lg font-semibold text-text-primary">{t('chat.title')}</h2>
+          <p className="text-sm text-text-secondary">{t('chat.description')}</p>
         </div>
       </div>
 
-      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-4 space-y-3">
+      <div className="rounded-xl border border-border-subtle bg-bg-elevated p-4 space-y-3">
         <div className="flex items-center justify-between gap-3">
           <button
             type="button"
@@ -1208,10 +1210,10 @@ export function ChatPanel() {
             aria-expanded={!visibilityPanelCollapsed}
           >
             <div>
-              <p className="text-sm font-medium text-[var(--text-primary)]">
+              <p className="text-sm font-medium text-text-primary">
                 {t('chat.visibility.title', { defaultValue: 'Visible platforms' })}
               </p>
-              <p className="text-xs text-[var(--text-tertiary)]">
+              <p className="text-xs text-text-tertiary">
                 {visiblePlatforms.length > 0
                   ? t('chat.visibility.mode.custom', { defaultValue: 'Custom' })
                   : t('chat.visibility.mode.auto', { defaultValue: 'Auto (active platforms)' })}
@@ -1219,7 +1221,7 @@ export function ChatPanel() {
             </div>
             <ChevronDown
               className={cn(
-                'w-4 h-4 text-[var(--text-tertiary)] transition-transform duration-200',
+                'w-4 h-4 text-text-tertiary transition-transform duration-200',
                 !visibilityPanelCollapsed && 'rotate-180'
               )}
             />
@@ -1235,7 +1237,7 @@ export function ChatPanel() {
         </div>
         {!visibilityPanelCollapsed && (
           <>
-            <p className="text-xs text-[var(--text-tertiary)]">
+            <p className="text-xs text-text-tertiary">
               {t(
                 'chat.visibility.hint',
                 'By default, active platforms are shown. Toggle to customize.'
@@ -1273,7 +1275,7 @@ export function ChatPanel() {
         )}
       </div>
 
-      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-4">
+      <div className="rounded-xl border border-border-subtle bg-bg-elevated p-4">
         <Toggle
           checked={crosspostEnabled}
           onChange={handleCrosspostChange}
@@ -1348,7 +1350,7 @@ export function ChatPanel() {
               onBlur={handleTrovoChannelSave}
               placeholder={t('chat.trovo.channelIdPlaceholder', 'e.g. 100000021')}
             />
-            <p className="text-xs text-[var(--text-tertiary)]">
+            <p className="text-xs text-text-tertiary">
               {t(
                 'chat.trovo.channelIdHint',
                 'Requires SPIRITSTREAM_TROVO_CLIENT_ID in environment. Read-only chat is supported.'
@@ -1362,13 +1364,13 @@ export function ChatPanel() {
               disabled
             />
             {getStatusForPlatform('trovo')?.error && (
-              <div className="flex items-start gap-2 p-3 rounded-lg bg-[var(--status-error)]/10 border border-[var(--status-error)]/20">
-                <AlertCircle className="w-4 h-4 text-[var(--status-error)] flex-shrink-0 mt-0.5" />
-                <p className="text-sm text-[var(--status-error)]">{getStatusForPlatform('trovo')?.error}</p>
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-status-error/10 border border-status-error/20">
+                <AlertCircle className="w-4 h-4 text-status-error flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-status-error">{getStatusForPlatform('trovo')?.error}</p>
               </div>
             )}
             <div className="flex items-center justify-between pt-2">
-              <p className="text-xs text-[var(--text-tertiary)]">
+              <p className="text-xs text-text-tertiary">
                 {t(
                   'chat.streamTiedHint',
                   'Chat connects when you start streaming. YouTube may take ~10s to activate.'
@@ -1397,8 +1399,8 @@ export function ChatPanel() {
           <Card>
           <CardHeader>
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-[var(--bg-base)]">
-                <MessageSquare className="w-5 h-5 text-[var(--text-secondary)]" />
+              <div className="p-2 rounded-lg bg-bg-base">
+                <MessageSquare className="w-5 h-5 text-text-secondary" />
               </div>
               <div className="flex-1">
                 <CardTitle>{t('chat.stripchat.title', 'Stripchat')}</CardTitle>
@@ -1423,9 +1425,9 @@ export function ChatPanel() {
               description={t('chat.stripchat.sendHint', 'Stripchat sending is not available yet')}
               disabled
             />
-            <div className="flex items-start gap-2 p-3 rounded-lg bg-[var(--status-warning)]/10 border border-[var(--status-warning)]/20">
-              <AlertCircle className="w-4 h-4 text-[var(--status-warning)] flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-[var(--status-warning)]">
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-warning/10 border border-warning/20">
+              <AlertCircle className="w-4 h-4 text-warning flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-warning">
                 {t(
                   'chat.stripchat.unavailableHint',
                   'Public Stripchat docs currently expose studio stats APIs, not a stable chat API.'

--- a/apps/web/src/components/integrations/DiscordPanel.tsx
+++ b/apps/web/src/components/integrations/DiscordPanel.tsx
@@ -23,11 +23,10 @@ import { useProfileStore } from '@/stores/profileStore';
 import { dialogs } from '@/lib/backend';
 import { api } from '@/lib/backend';
 import { toast } from '@/hooks/useToast';
+import { logger } from '@/lib/logger';
 import { cn } from '@/lib/cn';
+import { AUTO_SAVE_DELAY_MS } from '@/lib/constants';
 import type { DiscordSettings } from '@/types/profile';
-
-// Debounce delay for auto-save (ms)
-const AUTO_SAVE_DELAY = 500;
 
 // Common emojis for streaming
 const EMOJI_CATEGORIES = [
@@ -98,7 +97,7 @@ export function DiscordPanel() {
         updateProfileSettings({
           discord: { ...discordSettings, ...pendingUpdatesRef.current },
         }).catch((error) => {
-          console.error('Failed to flush Discord settings on unmount:', error);
+          logger.error('Failed to flush Discord settings on unmount:', error);
         });
         pendingUpdatesRef.current = null;
       }
@@ -137,9 +136,9 @@ export function DiscordPanel() {
           });
           pendingUpdatesRef.current = null; // Clear after successful save
         } catch (error) {
-          console.error('Failed to save Discord setting:', error);
+          logger.error('Failed to save Discord setting:', error);
         }
-      }, AUTO_SAVE_DELAY);
+      }, AUTO_SAVE_DELAY_MS);
     },
     [discordSettings, updateProfileSettings]
   );
@@ -154,7 +153,7 @@ export function DiscordPanel() {
           discord: { ...discordSettings, webhookEnabled: checked },
         });
       } catch (error) {
-        console.error('Failed to save webhook enabled state:', error);
+        logger.error('Failed to save webhook enabled state:', error);
       }
     },
     [discordSettings, updateProfileSettings]
@@ -184,7 +183,7 @@ export function DiscordPanel() {
           discord: { ...discordSettings, cooldownEnabled: checked },
         });
       } catch (error) {
-        console.error('Failed to save cooldown enabled state:', error);
+        logger.error('Failed to save cooldown enabled state:', error);
       }
     },
     [discordSettings, updateProfileSettings]
@@ -213,7 +212,7 @@ export function DiscordPanel() {
         });
       }
     } catch (error) {
-      console.error('Failed to select image:', error);
+      logger.error('Failed to select image:', error);
       toast.error(t('common.error'));
     }
   }, [t, discordSettings, updateProfileSettings]);
@@ -227,7 +226,7 @@ export function DiscordPanel() {
         discord: { ...discordSettings, imagePath: '' },
       });
     } catch (error) {
-      console.error('Failed to remove image:', error);
+      logger.error('Failed to remove image:', error);
     }
   }, [discordSettings, updateProfileSettings]);
 
@@ -301,7 +300,7 @@ export function DiscordPanel() {
   // Show message if no profile is loaded
   if (!currentProfile) {
     return (
-      <div className="flex items-center justify-center p-8 text-[var(--text-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-text-tertiary">
         {t('common.loadProfileFirst', 'Please load a profile first')}
       </div>
     );
@@ -311,12 +310,12 @@ export function DiscordPanel() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-[var(--bg-elevated)]">
+        <div className="p-2 rounded-lg bg-bg-elevated">
           <MessageSquare className="w-5 h-5 text-[#5865F2]" />
         </div>
         <div>
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t('discord.title')}</h2>
-          <p className="text-sm text-[var(--text-secondary)]">{t('discord.description')}</p>
+          <h2 className="text-lg font-semibold text-text-primary">{t('discord.title')}</h2>
+          <p className="text-sm text-text-secondary">{t('discord.description')}</p>
         </div>
       </div>
 
@@ -371,7 +370,7 @@ export function DiscordPanel() {
                 </Button>
               </div>
               {webhookUrl && !isValidWebhookUrl && (
-                <div className="flex items-center gap-2 text-xs text-[var(--status-error)]">
+                <div className="flex items-center gap-2 text-xs text-status-error">
                   <AlertCircle className="w-3 h-3" />
                   <span>{t('discord.invalidWebhookUrl')}</span>
                 </div>
@@ -396,7 +395,7 @@ export function DiscordPanel() {
                 <div
                   className={cn(
                     'flex items-center gap-2 text-sm',
-                    testResult.success ? 'text-[var(--status-live)]' : 'text-[var(--status-error)]'
+                    testResult.success ? 'text-status-live' : 'text-status-error'
                   )}
                 >
                   {testResult.success ? (
@@ -441,16 +440,16 @@ export function DiscordPanel() {
                   disabled={!webhookEnabled || !cooldownEnabled}
                 />
               </div>
-              <div className="flex items-center gap-2 pb-2 text-sm text-[var(--text-tertiary)]">
+              <div className="flex items-center gap-2 pb-2 text-sm text-text-tertiary">
                 <Timer className="w-4 h-4" />
                 <span>{t('discord.seconds')}</span>
               </div>
             </div>
 
             {/* Info about cooldown */}
-            <div className="flex items-start gap-2 p-3 rounded-lg bg-[var(--bg-base)] border border-[var(--border-default)]">
-              <Info className="w-4 h-4 text-[var(--text-tertiary)] flex-shrink-0 mt-0.5" />
-              <p className="text-xs text-[var(--text-tertiary)]">{t('discord.cooldownInfo')}</p>
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-bg-base border border-border-default">
+              <Info className="w-4 h-4 text-text-tertiary flex-shrink-0 mt-0.5" />
+              <p className="text-xs text-text-tertiary">{t('discord.cooldownInfo')}</p>
             </div>
           </CardBody>
         </Card>
@@ -475,10 +474,10 @@ export function DiscordPanel() {
                 rows={4}
                 className={cn(
                   'w-full px-3 py-2 pr-10 rounded-lg',
-                  'bg-[var(--bg-input)] border border-[var(--border-default)]',
-                  'text-sm text-[var(--text-primary)]',
-                  'placeholder:text-[var(--text-placeholder)]',
-                  'focus:outline-none focus:ring-2 focus:ring-[var(--ring-default)] focus:border-transparent',
+                  'bg-bg-sunken border border-border-default',
+                  'text-sm text-text-primary',
+                  'placeholder:text-text-muted',
+                  'focus:outline-none focus:ring-2 focus:ring-ring-default focus:border-transparent',
                   'disabled:opacity-50 disabled:cursor-not-allowed',
                   'resize-y min-h-[100px]'
                 )}
@@ -492,8 +491,8 @@ export function DiscordPanel() {
                   disabled={!webhookEnabled}
                   className={cn(
                     'p-1.5 rounded-md transition-colors',
-                    'text-[var(--text-tertiary)] hover:text-[var(--text-primary)]',
-                    'hover:bg-[var(--bg-muted)]',
+                    'text-text-tertiary hover:text-text-primary',
+                    'hover:bg-bg-muted',
                     'disabled:opacity-50 disabled:cursor-not-allowed'
                   )}
                   title={t('discord.insertEmoji')}
@@ -503,10 +502,10 @@ export function DiscordPanel() {
 
                 {/* Emoji Picker Dropdown */}
                 {showEmojiPicker && (
-                  <div className="absolute right-0 top-full mt-1 z-50 p-2 rounded-lg bg-[var(--bg-surface)] border border-[var(--border-default)] shadow-lg w-64">
+                  <div className="absolute right-0 top-full mt-1 z-50 p-2 rounded-lg bg-bg-surface border border-border-default shadow-lg w-64">
                     {EMOJI_CATEGORIES.map((category) => (
                       <div key={category.nameKey} className="mb-2 last:mb-0">
-                        <div className="text-xs text-[var(--text-tertiary)] mb-1 px-1">
+                        <div className="text-xs text-text-tertiary mb-1 px-1">
                           {t(category.nameKey)}
                         </div>
                         <div className="flex flex-wrap gap-1">
@@ -515,7 +514,7 @@ export function DiscordPanel() {
                               key={emoji}
                               type="button"
                               onClick={() => handleEmojiSelect(emoji)}
-                              className="p-1.5 rounded hover:bg-[var(--bg-muted)] text-lg transition-colors"
+                              className="p-1.5 rounded hover:bg-bg-muted text-lg transition-colors"
                             >
                               {emoji}
                             </button>
@@ -530,9 +529,9 @@ export function DiscordPanel() {
           </div>
 
           {/* Markdown hint */}
-          <div className="flex items-start gap-2 p-3 rounded-lg bg-[var(--bg-base)] border border-[var(--border-default)]">
-            <Info className="w-4 h-4 text-[var(--text-tertiary)] flex-shrink-0 mt-0.5" />
-            <div className="text-xs text-[var(--text-tertiary)] space-y-1">
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-bg-base border border-border-default">
+            <Info className="w-4 h-4 text-text-tertiary flex-shrink-0 mt-0.5" />
+            <div className="text-xs text-text-tertiary space-y-1">
               <p>{t('discord.markdownSupport')}</p>
               <p className="font-mono">
                 {t('discord.markdownExample')}
@@ -542,13 +541,13 @@ export function DiscordPanel() {
 
           {/* Image Attachment */}
           <div className="space-y-2">
-            <label className="block text-sm font-medium text-[var(--text-primary)]">
+            <label className="block text-sm font-medium text-text-primary">
               {t('discord.attachImage')}
             </label>
             {imagePath ? (
-              <div className="flex items-center gap-3 p-3 rounded-lg bg-[var(--bg-base)] border border-[var(--border-default)]">
-                <ImageIcon className="w-5 h-5 text-[var(--text-tertiary)]" />
-                <span className="flex-1 text-sm text-[var(--text-primary)] truncate">
+              <div className="flex items-center gap-3 p-3 rounded-lg bg-bg-base border border-border-default">
+                <ImageIcon className="w-5 h-5 text-text-tertiary" />
+                <span className="flex-1 text-sm text-text-primary truncate">
                   {imageFileName}
                 </span>
                 <Button
@@ -571,7 +570,7 @@ export function DiscordPanel() {
                 {t('discord.selectImage')}
               </Button>
             )}
-            <p className="text-xs text-[var(--text-tertiary)]">
+            <p className="text-xs text-text-tertiary">
               {t('discord.imageHint')}
             </p>
           </div>

--- a/apps/web/src/components/integrations/ObsPanel.tsx
+++ b/apps/web/src/components/integrations/ObsPanel.tsx
@@ -19,11 +19,10 @@ import { Toggle } from '@/components/ui/Toggle';
 import { useObsStore } from '@/stores/obsStore';
 import { useProfileStore } from '@/stores/profileStore';
 import { toast } from '@/hooks/useToast';
+import { logger } from '@/lib/logger';
 import { cn } from '@/lib/cn';
+import { AUTO_SAVE_DELAY_MS } from '@/lib/constants';
 import type { ObsIntegrationDirection } from '@/types/api';
-
-// Debounce delay for auto-save (ms)
-const AUTO_SAVE_DELAY = 500;
 
 const directionOptions: { value: ObsIntegrationDirection; labelKey: string; descKey: string }[] = [
   {
@@ -105,7 +104,7 @@ export function ObsPanel() {
       // Flush any pending updates
       if (pendingUpdatesRef.current) {
         updateConfig(pendingUpdatesRef.current).catch((error) => {
-          console.error('Failed to flush OBS config on unmount:', error);
+          logger.error('Failed to flush OBS config on unmount:', error);
         });
         pendingUpdatesRef.current = null;
       }
@@ -127,9 +126,9 @@ export function ObsPanel() {
           await updateConfig(pendingUpdatesRef.current!);
           pendingUpdatesRef.current = null; // Clear after successful save
         } catch (error) {
-          console.error('Failed to save OBS config:', error);
+          logger.error('Failed to save OBS config:', error);
         }
-      }, AUTO_SAVE_DELAY);
+      }, AUTO_SAVE_DELAY_MS);
     },
     [updateConfig]
   );
@@ -178,7 +177,7 @@ export function ObsPanel() {
       try {
         await updateConfig({ useAuth: checked });
       } catch (error) {
-        console.error('Failed to save useAuth:', error);
+        logger.error('Failed to save useAuth:', error);
       }
     },
     [updateConfig]
@@ -191,7 +190,7 @@ export function ObsPanel() {
       try {
         await updateConfig({ autoConnect: checked });
       } catch (error) {
-        console.error('Failed to save autoConnect:', error);
+        logger.error('Failed to save autoConnect:', error);
       }
     },
     [updateConfig]
@@ -221,13 +220,13 @@ export function ObsPanel() {
   const getStatusIcon = () => {
     switch (connectionStatus) {
       case 'connected':
-        return <Wifi className="w-4 h-4 text-[var(--status-live)]" />;
+        return <Wifi className="w-4 h-4 text-status-live" />;
       case 'connecting':
-        return <Loader2 className="w-4 h-4 text-[var(--status-connecting)] animate-spin" />;
+        return <Loader2 className="w-4 h-4 text-status-connecting animate-spin" />;
       case 'error':
-        return <AlertCircle className="w-4 h-4 text-[var(--status-error)]" />;
+        return <AlertCircle className="w-4 h-4 text-status-error" />;
       default:
-        return <WifiOff className="w-4 h-4 text-[var(--text-tertiary)]" />;
+        return <WifiOff className="w-4 h-4 text-text-tertiary" />;
     }
   };
 
@@ -246,7 +245,7 @@ export function ObsPanel() {
 
   if (!currentProfile) {
     return (
-      <div className="flex items-center justify-center p-8 text-[var(--text-tertiary)]">
+      <div className="flex items-center justify-center p-8 text-text-tertiary">
         {t('common.loadProfileFirst', 'Please load a profile first')}
       </div>
     );
@@ -256,12 +255,12 @@ export function ObsPanel() {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-[var(--bg-elevated)]">
-          <Radio className="w-5 h-5 text-[var(--primary)]" />
+        <div className="p-2 rounded-lg bg-bg-elevated">
+          <Radio className="w-5 h-5 text-primary" />
         </div>
         <div>
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t('obs.title')}</h2>
-          <p className="text-sm text-[var(--text-secondary)]">{t('obs.description')}</p>
+          <h2 className="text-lg font-semibold text-text-primary">{t('obs.title')}</h2>
+          <p className="text-sm text-text-secondary">{t('obs.description')}</p>
         </div>
       </div>
 
@@ -355,15 +354,15 @@ export function ObsPanel() {
           </CardHeader>
           <CardBody className="space-y-4">
             {/* Connection Status */}
-            <div className="flex items-center justify-between p-3 rounded-lg bg-[var(--bg-base)]">
+            <div className="flex items-center justify-between p-3 rounded-lg bg-bg-base">
               <div className="flex items-center gap-3">
                 {getStatusIcon()}
                 <div>
-                  <div className="text-sm font-medium text-[var(--text-primary)]">
+                  <div className="text-sm font-medium text-text-primary">
                     {getStatusText()}
                   </div>
                   {isConnected && obsVersion && (
-                    <div className="text-xs text-[var(--text-tertiary)]">
+                    <div className="text-xs text-text-tertiary">
                       {t('obs.versionInfo', { obsVersion, wsVersion: websocketVersion })}
                     </div>
                   )}
@@ -396,21 +395,21 @@ export function ObsPanel() {
 
             {/* Error Message */}
             {errorMessage && (
-              <div className="flex items-start gap-2 p-3 rounded-lg bg-[var(--status-error)]/10 border border-[var(--status-error)]/20">
-                <AlertCircle className="w-4 h-4 text-[var(--status-error)] flex-shrink-0 mt-0.5" />
-                <p className="text-sm text-[var(--status-error)]">{errorMessage}</p>
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-status-error/10 border border-status-error/20">
+                <AlertCircle className="w-4 h-4 text-status-error flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-status-error">{errorMessage}</p>
               </div>
             )}
 
             {/* OBS Stream Status (read-only indicator) */}
             {isConnected && (
-              <div className="flex items-center gap-2 p-3 rounded-lg bg-[var(--bg-base)]">
+              <div className="flex items-center gap-2 p-3 rounded-lg bg-bg-base">
                 {streamStatus === 'active' ? (
-                  <CheckCircle2 className="w-4 h-4 text-[var(--status-live)]" />
+                  <CheckCircle2 className="w-4 h-4 text-status-live" />
                 ) : (
-                  <Square className="w-4 h-4 text-[var(--text-tertiary)]" />
+                  <Square className="w-4 h-4 text-text-tertiary" />
                 )}
-                <span className="text-sm text-[var(--text-primary)]">
+                <span className="text-sm text-text-primary">
                   {streamStatus === 'active' ? t('obs.streaming') : t('obs.notStreaming')}
                 </span>
               </div>
@@ -434,19 +433,19 @@ export function ObsPanel() {
                 onClick={() => {
                   setDirection(option.value);
                   // Auto-save direction changes
-                  updateConfig({ direction: option.value }).catch(console.error);
+                  updateConfig({ direction: option.value }).catch(logger.error);
                 }}
                 className={cn(
                   'p-4 rounded-lg border text-left transition-all cursor-pointer',
                   direction === option.value
-                    ? 'border-[var(--primary)] bg-[var(--primary)]/10'
-                    : 'border-[var(--border-default)] bg-[var(--bg-base)] hover:border-[var(--border-strong)]'
+                    ? 'border-primary bg-primary/10'
+                    : 'border-border-default bg-bg-base hover:border-border-strong'
                 )}
               >
-                <div className="text-sm font-medium text-[var(--text-primary)]">
+                <div className="text-sm font-medium text-text-primary">
                   {t(option.labelKey as 'obs.directions.disabled')}
                 </div>
-                <div className="text-xs text-[var(--text-tertiary)] mt-1">
+                <div className="text-xs text-text-tertiary mt-1">
                   {t(option.descKey as 'obs.directions.disabledDescription')}
                 </div>
               </button>

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -6,5 +6,5 @@ export interface AppShellProps {
 }
 
 export function AppShell({ children, className }: AppShellProps) {
-  return <div className={cn('flex min-h-screen bg-[var(--bg-base)]', className)}>{children}</div>;
+  return <div className={cn('flex min-h-screen bg-bg-base', className)}>{children}</div>;
 }

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -11,17 +11,17 @@ export function Header({ title, description, children, className }: HeaderProps)
   return (
     <header
       className={cn(
-        'bg-[var(--bg-surface)] border-b border-[var(--border-default)]',
+        'bg-bg-surface border-b border-border-default',
         'flex items-center justify-between',
         'sticky top-0 z-50',
+        'py-4 px-6',
         className
       )}
-      style={{ padding: '16px 24px' }}
     >
       <div className="flex flex-col">
-        <h1 className="text-xl font-semibold text-[var(--text-primary)]">{title}</h1>
+        <h1 className="text-xl font-semibold text-text-primary">{title}</h1>
         {description && (
-          <p className="text-sm text-[var(--text-secondary)] mt-0.5">{description}</p>
+          <p className="text-sm text-text-secondary mt-0.5">{description}</p>
         )}
       </div>
       {children && <div className="flex items-center gap-3">{children}</div>}

--- a/apps/web/src/components/layout/Logo.tsx
+++ b/apps/web/src/components/layout/Logo.tsx
@@ -14,13 +14,13 @@ export function Logo({ size = 'md', showText = true, className }: LogoProps) {
   };
 
   return (
-    <div className={cn('flex items-center', className)} style={{ gap: '12px' }}>
+    <div className={cn('flex items-center gap-3', className)}>
       <img
         src="/app-icon.png"
         alt="SpiritStream"
         className={cn(
           'rounded-xl',
-          'shadow-[var(--shadow-md)]',
+          'shadow-md',
           sizes[size]
         )}
       />

--- a/apps/web/src/components/layout/MainContent.tsx
+++ b/apps/web/src/components/layout/MainContent.tsx
@@ -8,8 +8,7 @@ export interface MainContentProps {
 export function MainContent({ children, className }: MainContentProps) {
   return (
     <main
-      className={cn('flex-1 flex flex-col min-h-screen', className)}
-      style={{ marginLeft: '260px' }}
+      className={cn('flex-1 flex flex-col min-h-screen ml-[260px]', className)}
     >
       {children}
     </main>
@@ -23,7 +22,7 @@ export interface ContentAreaProps {
 
 export function ContentArea({ children, className }: ContentAreaProps) {
   return (
-    <div className={cn('flex-1 overflow-y-auto', className)} style={{ padding: '24px' }}>
+    <div className={cn('flex-1 overflow-y-auto p-6', className)}>
       {children}
     </div>
   );

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -9,7 +9,7 @@ export function Sidebar({ children, className }: SidebarProps) {
   return (
     <aside
       className={cn(
-        'w-[260px] bg-[var(--bg-surface)] border-r border-[var(--border-default)]',
+        'w-[260px] bg-bg-surface border-r border-border-default',
         'flex flex-col fixed top-0 left-0 bottom-0 z-[100]',
         className
       )}
@@ -27,8 +27,7 @@ export interface SidebarHeaderProps {
 export function SidebarHeader({ children, className }: SidebarHeaderProps) {
   return (
     <div
-      className={cn('border-b border-[var(--border-muted)]', 'flex items-center gap-3', className)}
-      style={{ padding: '20px 16px' }}
+      className={cn('border-b border-border-muted', 'flex items-center gap-3 py-5 px-4', className)}
     >
       {children}
     </div>
@@ -42,7 +41,7 @@ export interface SidebarNavProps {
 
 export function SidebarNav({ children, className }: SidebarNavProps) {
   return (
-    <nav className={cn('flex-1 overflow-y-auto', className)} style={{ padding: '16px 12px' }}>
+    <nav className={cn('flex-1 overflow-y-auto py-4 px-3', className)}>
       {children}
     </nav>
   );
@@ -56,8 +55,7 @@ export interface SidebarFooterProps {
 export function SidebarFooter({ children, className }: SidebarFooterProps) {
   return (
     <div
-      className={cn('border-t border-[var(--border-muted)]', className)}
-      style={{ padding: '16px' }}
+      className={cn('border-t border-border-muted p-4', className)}
     >
       {children}
     </div>

--- a/apps/web/src/components/modals/FileBrowserModal.tsx
+++ b/apps/web/src/components/modals/FileBrowserModal.tsx
@@ -13,6 +13,7 @@ import {
   CornerDownLeft,
 } from 'lucide-react';
 import { getBackendBaseUrl, getAuthHeaders, safeFetch } from '@/lib/backend/env';
+import { logger } from '@/lib/logger';
 
 interface FileEntry {
   name: string;
@@ -205,7 +206,7 @@ export function FileBrowserModal({
         setEntries(data.entries);
         setParentPath(data.parent ?? null);
       } catch (err) {
-        console.error('[FileBrowser] Browse failed:', err);
+        logger.error('[FileBrowser] Browse failed:', err);
         // Map server errors to user-friendly messages
         const errorMessage = err instanceof Error ? err.message : 'Failed to browse directory';
         const friendlyError = getFriendlyError(errorMessage, t);
@@ -449,7 +450,7 @@ export function FileBrowserModal({
             onKeyDown={handlePathKeyDown}
             onFocus={() => setIsEditingPath(true)}
             placeholder={t('fileBrowser.typePath', 'Type a path and press Enter...')}
-            className="flex-1 px-3 py-1.5 bg-[var(--bg-sunken)] rounded text-sm font-mono text-[var(--text-secondary)] border border-transparent focus:border-[var(--primary)] focus:outline-none"
+            className="flex-1 px-3 py-1.5 bg-bg-sunken rounded text-sm font-mono text-text-secondary border border-transparent focus:border-primary focus:outline-none"
           />
           {isEditingPath && pathInput !== currentPath && (
             <Button
@@ -467,7 +468,7 @@ export function FileBrowserModal({
         {/* Quick path shortcuts */}
         {quickPaths.length > 0 && (
           <div className="flex items-center gap-2 mb-3 flex-wrap">
-            <span className="text-xs text-[var(--text-muted)]">
+            <span className="text-xs text-text-muted">
               {t('fileBrowser.quickPaths', 'Quick paths:')}
             </span>
             {quickPaths.map((quickPath) => (
@@ -475,7 +476,7 @@ export function FileBrowserModal({
                 key={quickPath.path}
                 type="button"
                 onClick={() => browse(quickPath.path)}
-                className="text-xs px-2 py-0.5 rounded bg-[var(--bg-muted)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] transition-colors"
+                className="text-xs px-2 py-0.5 rounded bg-bg-muted hover:bg-bg-hover text-text-secondary transition-colors"
               >
                 {quickPath.label}
               </button>
@@ -484,26 +485,26 @@ export function FileBrowserModal({
         )}
 
         {/* File list */}
-        <div className="border border-[var(--border-default)] rounded-lg bg-[var(--bg-sunken)] h-[300px] overflow-y-auto">
+        <div className="border border-border-default rounded-lg bg-bg-sunken h-[300px] overflow-y-auto">
           {loading ? (
-            <div className="flex items-center justify-center h-full text-[var(--text-tertiary)]">
+            <div className="flex items-center justify-center h-full text-text-tertiary">
               {t('common.loading', 'Loading...')}
             </div>
           ) : error ? (
             <div className="flex flex-col items-center justify-center h-full p-4 text-center">
-              <p className="text-[var(--error-text)] mb-2">{error}</p>
+              <p className="text-error-text mb-2">{error}</p>
               <Button variant="outline" size="sm" onClick={() => browse(currentPath)}>
                 {t('common.retry', 'Retry')}
               </Button>
             </div>
           ) : filteredEntries.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-[var(--text-tertiary)]">
+            <div className="flex items-center justify-center h-full text-text-tertiary">
               {mode === 'directory'
                 ? t('fileBrowser.noSubdirectories', 'No subdirectories')
                 : t('fileBrowser.noFiles', 'No matching files')}
             </div>
           ) : (
-            <div className="divide-y divide-[var(--border-muted)]">
+            <div className="divide-y divide-border-muted">
               {filteredEntries.map((entry) => (
                 <div
                   key={entry.name}
@@ -513,26 +514,26 @@ export function FileBrowserModal({
                     flex items-center gap-3 px-3 py-2 cursor-pointer transition-colors
                     ${
                       selectedEntry === entry.name
-                        ? 'bg-[var(--primary-subtle)]'
-                        : 'hover:bg-[var(--bg-hover)]'
+                        ? 'bg-primary-subtle'
+                        : 'hover:bg-bg-hover'
                     }
                   `}
                 >
                   {entry.type === 'directory' ? (
-                    <FolderOpen className="w-5 h-5 text-[var(--warning)]" />
+                    <FolderOpen className="w-5 h-5 text-warning" />
                   ) : (
-                    <File className="w-5 h-5 text-[var(--text-tertiary)]" />
+                    <File className="w-5 h-5 text-text-tertiary" />
                   )}
-                  <span className="flex-1 text-sm text-[var(--text-primary)] truncate">
+                  <span className="flex-1 text-sm text-text-primary truncate">
                     {entry.name}
                   </span>
                   {entry.type === 'file' && entry.size !== undefined && (
-                    <span className="text-xs text-[var(--text-muted)]">
+                    <span className="text-xs text-text-muted">
                       {formatSize(entry.size)}
                     </span>
                   )}
                   {entry.type === 'directory' && (
-                    <Folder className="w-4 h-4 text-[var(--text-muted)]" />
+                    <Folder className="w-4 h-4 text-text-muted" />
                   )}
                 </div>
               ))}
@@ -554,11 +555,11 @@ export function FileBrowserModal({
 
         {/* Current selection info */}
         {mode === 'directory' && currentPath && (
-          <div className="mt-3 p-2 bg-[var(--bg-muted)] rounded text-sm">
-            <span className="text-[var(--text-tertiary)]">
+          <div className="mt-3 p-2 bg-bg-muted rounded text-sm">
+            <span className="text-text-tertiary">
               {t('fileBrowser.selectedDirectory', 'Selected directory:')}
             </span>{' '}
-            <span className="font-mono text-[var(--text-secondary)]">{currentPath}</span>
+            <span className="font-mono text-text-secondary">{currentPath}</span>
           </div>
         )}
       </ModalBody>

--- a/apps/web/src/components/modals/KeyRotationModal.tsx
+++ b/apps/web/src/components/modals/KeyRotationModal.tsx
@@ -42,36 +42,36 @@ export function KeyRotationModal({
         </>
       }
     >
-      <div className="flex flex-col" style={{ gap: '16px' }}>
-        <p className="text-sm text-[var(--text-secondary)]">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-text-secondary">
           {t('settings.rotateMachineKeyDescription')}
         </p>
 
-        <div className="flex flex-col" style={{ gap: '10px' }}>
-          <div className="text-sm font-medium text-[var(--text-primary)]">
+        <div className="flex flex-col gap-2.5">
+          <div className="text-sm font-medium text-text-primary">
             {t('settings.rotationStepsTitle')}
           </div>
-          <div className="flex items-start" style={{ gap: '8px' }}>
-            <CheckCircle2 className="w-4 h-4 text-[var(--success-text)] mt-0.5" />
-            <span className="text-sm text-[var(--text-secondary)]">
+          <div className="flex items-start gap-2">
+            <CheckCircle2 className="w-4 h-4 text-success-text mt-0.5" />
+            <span className="text-sm text-text-secondary">
               {t('settings.rotationStepGenerate')}
             </span>
           </div>
-          <div className="flex items-start" style={{ gap: '8px' }}>
-            <CheckCircle2 className="w-4 h-4 text-[var(--success-text)] mt-0.5" />
-            <span className="text-sm text-[var(--text-secondary)]">
+          <div className="flex items-start gap-2">
+            <CheckCircle2 className="w-4 h-4 text-success-text mt-0.5" />
+            <span className="text-sm text-text-secondary">
               {t('settings.rotationStepBackup')}
             </span>
           </div>
-          <div className="flex items-start" style={{ gap: '8px' }}>
-            <CheckCircle2 className="w-4 h-4 text-[var(--success-text)] mt-0.5" />
-            <span className="text-sm text-[var(--text-secondary)]">
+          <div className="flex items-start gap-2">
+            <CheckCircle2 className="w-4 h-4 text-success-text mt-0.5" />
+            <span className="text-sm text-text-secondary">
               {t('settings.rotationStepReencrypt')}
             </span>
           </div>
-          <div className="flex items-start" style={{ gap: '8px' }}>
-            <CheckCircle2 className="w-4 h-4 text-[var(--success-text)] mt-0.5" />
-            <span className="text-sm text-[var(--text-secondary)]">
+          <div className="flex items-start gap-2">
+            <CheckCircle2 className="w-4 h-4 text-success-text mt-0.5" />
+            <span className="text-sm text-text-secondary">
               {t('settings.rotationStepDelete')}
             </span>
           </div>
@@ -88,7 +88,7 @@ export function KeyRotationModal({
         )}
 
         {inProgress && (
-          <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+          <div className="flex items-center gap-2 text-sm text-text-secondary">
             <Loader2 className="w-4 h-4 animate-spin" />
             {t('settings.rotationInProgress')}
           </div>

--- a/apps/web/src/components/modals/LoginModal.tsx
+++ b/apps/web/src/components/modals/LoginModal.tsx
@@ -67,9 +67,9 @@ export function LoginModal({ open, onSuccess }: LoginModalProps) {
     >
       <form onSubmit={handleSubmit}>
         <ModalBody>
-          <div className="flex items-center gap-3 mb-4 p-3 bg-[var(--bg-muted)] rounded-lg">
-            <ShieldCheck className="w-5 h-5 text-[var(--primary)]" />
-            <p className="text-sm text-[var(--text-secondary)]">
+          <div className="flex items-center gap-3 mb-4 p-3 bg-bg-muted rounded-lg">
+            <ShieldCheck className="w-5 h-5 text-primary" />
+            <p className="text-sm text-text-secondary">
               {t(
                 'login.description',
                 'This SpiritStream server requires authentication. Please enter your API token to continue.'
@@ -94,7 +94,7 @@ export function LoginModal({ open, onSuccess }: LoginModalProps) {
                 onClick={() => setShowToken(!showToken)}
                 aria-label={showToken ? t('common.hidePassword') : t('common.showPassword')}
                 aria-pressed={showToken}
-                className="absolute right-3 top-[34px] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+                className="absolute right-3 top-[34px] text-text-tertiary hover:text-text-primary transition-colors"
                 disabled={loading}
               >
                 {showToken ? (
@@ -106,12 +106,12 @@ export function LoginModal({ open, onSuccess }: LoginModalProps) {
             </div>
 
             {error && (
-              <div className="p-3 bg-[var(--error-subtle)] border border-[var(--error-border)] rounded-lg">
-                <p className="text-sm text-[var(--error-text)]">{error}</p>
+              <div className="p-3 bg-error-subtle border border-error-border rounded-lg">
+                <p className="text-sm text-error-text">{error}</p>
               </div>
             )}
 
-            <div className="text-xs text-[var(--text-tertiary)]">
+            <div className="text-xs text-text-tertiary">
               <p>
                 {t(
                   'login.tokenHint',

--- a/apps/web/src/components/modals/OutputGroupModal.tsx
+++ b/apps/web/src/components/modals/OutputGroupModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal } from '@/components/ui/Modal';
 import { Input } from '@/components/ui/Input';
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/Button';
 import { Toggle } from '@/components/ui/Toggle';
 import { useProfileStore } from '@/stores/profileStore';
 import { api } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import type { OutputGroup, VideoSettings, AudioSettings, ContainerSettings } from '@/types/profile';
 import type { Encoders } from '@/types/stream';
 
@@ -138,11 +139,12 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
   // Check if trying to edit the default (immutable) group
   const isDefaultGroup = mode === 'edit' && group?.isDefault === true;
 
-  // If trying to edit default group, close modal immediately and return null
-  if (isDefaultGroup && open) {
-    setTimeout(() => onClose(), 0);
-    return null;
-  }
+  // Close modal when attempting to edit the default (immutable) group
+  useEffect(() => {
+    if (isDefaultGroup && open) {
+      onClose();
+    }
+  }, [isDefaultGroup, open, onClose]);
 
   // Load available encoders when modal opens
   useEffect(() => {
@@ -162,7 +164,7 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
           }
         })
         .catch((err) => {
-          console.error('Failed to load encoders:', err);
+          logger.error('Failed to load encoders:', err);
         })
         .finally(() => {
           setLoadingEncoders(false);
@@ -211,16 +213,24 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
     options?: { defaultValue?: string; [key: string]: string | number | undefined }
   ) => string;
 
-  const videoCodecOptions: SelectOption[] = encoders.video.map((enc) => {
-    const defaultLabel = ENCODER_DEFAULT_LABELS[enc] || enc;
-    const label = tDynamic(`encoder.encoders.${enc}`, { defaultValue: defaultLabel });
-    return { value: enc, label };
-  });
+  const videoCodecOptions: SelectOption[] = useMemo(
+    () =>
+      encoders.video.map((enc) => {
+        const defaultLabel = ENCODER_DEFAULT_LABELS[enc] || enc;
+        const label = tDynamic(`encoder.encoders.${enc}`, { defaultValue: defaultLabel });
+        return { value: enc, label };
+      }),
+    [encoders.video, tDynamic]
+  );
 
-  const audioCodecOptions: SelectOption[] = encoders.audio.map((enc) => {
-    const label = tDynamic(`audio.codecs.${enc}`, { defaultValue: enc });
-    return { value: enc, label };
-  });
+  const audioCodecOptions: SelectOption[] = useMemo(
+    () =>
+      encoders.audio.map((enc) => {
+        const label = tDynamic(`audio.codecs.${enc}`, { defaultValue: enc });
+        return { value: enc, label };
+      }),
+    [encoders.audio, tDynamic]
+  );
 
   const presetValues = useMemo(
     () => getPresetValues(formData.videoCodec),
@@ -228,70 +238,102 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
   );
   const presetSupported = presetValues.length > 0;
 
-  // Create translated options arrays
-  const resolutionOptions: SelectOption[] = RESOLUTION_VALUES.map((value) => ({
-    value,
-    label: tDynamic(`encoder.resolutions.${value}`, { defaultValue: value }),
-  }));
-
-  const fpsOptions: SelectOption[] = FPS_VALUES.map((value) => ({
-    value,
-    label: tDynamic(`encoder.frameRates.${value}`, { defaultValue: `${value} fps` }),
-  }));
-
-  const audioBitrateOptions: SelectOption[] = AUDIO_BITRATE_VALUES.map((value) => ({
-    value,
-    label: tDynamic(`audio.bitrates.${value}`, { defaultValue: value }),
-  }));
-
-  const audioChannelsOptions: SelectOption[] = AUDIO_CHANNELS_VALUES.map((value) => {
-    if (value === '1') {
-      return {
+  // Create translated options arrays (memoized to avoid re-creating on every render)
+  const resolutionOptions: SelectOption[] = useMemo(
+    () =>
+      RESOLUTION_VALUES.map((value) => ({
         value,
-        label: tDynamic('audio.channels.mono', { defaultValue: 'Mono' }),
-      };
-    }
-    if (value === '2') {
-      return {
+        label: tDynamic(`encoder.resolutions.${value}`, { defaultValue: value }),
+      })),
+    [tDynamic]
+  );
+
+  const fpsOptions: SelectOption[] = useMemo(
+    () =>
+      FPS_VALUES.map((value) => ({
         value,
-        label: tDynamic('audio.channels.stereo', { defaultValue: 'Stereo' }),
-      };
-    }
-    return {
-      value,
-      label: tDynamic('audio.channels.multiple', {
-        defaultValue: '{{count}} channels',
-        count: value,
+        label: tDynamic(`encoder.frameRates.${value}`, { defaultValue: `${value} fps` }),
+      })),
+    [tDynamic]
+  );
+
+  const audioBitrateOptions: SelectOption[] = useMemo(
+    () =>
+      AUDIO_BITRATE_VALUES.map((value) => ({
+        value,
+        label: tDynamic(`audio.bitrates.${value}`, { defaultValue: value }),
+      })),
+    [tDynamic]
+  );
+
+  const audioChannelsOptions: SelectOption[] = useMemo(
+    () =>
+      AUDIO_CHANNELS_VALUES.map((value) => {
+        if (value === '1') {
+          return {
+            value,
+            label: tDynamic('audio.channels.mono', { defaultValue: 'Mono' }),
+          };
+        }
+        if (value === '2') {
+          return {
+            value,
+            label: tDynamic('audio.channels.stereo', { defaultValue: 'Stereo' }),
+          };
+        }
+        return {
+          value,
+          label: tDynamic('audio.channels.multiple', {
+            defaultValue: '{{count}} channels',
+            count: value,
+          }),
+        };
       }),
-    };
-  });
+    [tDynamic]
+  );
 
-  const audioSampleRateOptions: SelectOption[] = AUDIO_SAMPLE_RATE_VALUES.map((value) => {
-    const khz = parseInt(value, 10) / 1000;
-    return {
-      value,
-      label: tDynamic('audio.sampleRateKHz', { defaultValue: '{{value}} kHz', value: khz }),
-    };
-  });
+  const audioSampleRateOptions: SelectOption[] = useMemo(
+    () =>
+      AUDIO_SAMPLE_RATE_VALUES.map((value) => {
+        const khz = parseInt(value, 10) / 1000;
+        return {
+          value,
+          label: tDynamic('audio.sampleRateKHz', { defaultValue: '{{value}} kHz', value: khz }),
+        };
+      }),
+    [tDynamic]
+  );
 
-  const containerFormatOptions: SelectOption[] = CONTAINER_FORMAT_VALUES.map((value) => ({
-    value,
-    label: value.toUpperCase(),
-  }));
-
-  const presetOptions: SelectOption[] = presetSupported
-    ? presetValues.map((value) => ({
+  const containerFormatOptions: SelectOption[] = useMemo(
+    () =>
+      CONTAINER_FORMAT_VALUES.map((value) => ({
         value,
-        label: tDynamic(`encoder.presets.${value}`, {
-          defaultValue: value.charAt(0).toUpperCase() + value.slice(1),
-        }),
-      }))
-    : [];
+        label: value.toUpperCase(),
+      })),
+    []
+  );
 
-  const profileOptions: SelectOption[] = PROFILE_VALUES.map((value) => ({
-    value,
-    label: value.charAt(0).toUpperCase() + value.slice(1),
-  }));
+  const presetOptions: SelectOption[] = useMemo(
+    () =>
+      presetSupported
+        ? presetValues.map((value) => ({
+            value,
+            label: tDynamic(`encoder.presets.${value}`, {
+              defaultValue: value.charAt(0).toUpperCase() + value.slice(1),
+            }),
+          }))
+        : [],
+    [presetSupported, presetValues, tDynamic]
+  );
+
+  const profileOptions: SelectOption[] = useMemo(
+    () =>
+      PROFILE_VALUES.map((value) => ({
+        value,
+        label: value.charAt(0).toUpperCase() + value.slice(1),
+      })),
+    []
+  );
 
   const validate = (): boolean => {
     const newErrors: Partial<FormData> = {};
@@ -391,16 +433,21 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
     }
   };
 
-  const handleChange =
+  const handleChange = useCallback(
     (field: keyof FormData) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
       setFormData((prev) => ({ ...prev, [field]: e.target.value }));
       // Clear error when user starts typing
-      if (errors[field]) {
-        setErrors((prev) => ({ ...prev, [field]: undefined }));
-      }
-    };
+      setErrors((prev) => (prev[field] ? { ...prev, [field]: undefined } : prev));
+    },
+    []
+  );
 
   const title = mode === 'create' ? t('modals.createOutputGroup') : t('modals.editOutputGroup');
+
+  // Don't render anything for the immutable default group
+  if (isDefaultGroup) {
+    return null;
+  }
 
   return (
     <Modal
@@ -423,17 +470,10 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
         </>
       }
     >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div className="flex flex-col gap-4">
         {/* Info message explaining custom output groups */}
         {mode === 'create' && (
-          <div style={{
-            padding: '12px',
-            backgroundColor: 'var(--primary-muted)',
-            borderRadius: '8px',
-            fontSize: '0.875rem',
-            color: 'var(--text-secondary)',
-            lineHeight: '1.5'
-          }}>
+          <div className="p-3 bg-primary-muted rounded-lg text-sm text-text-secondary leading-normal">
             {tDynamic('modals.outputGroupExplanation', {
               defaultValue: 'Custom output groups re-encode your incoming stream to different settings. Use these when you need to send different quality streams to different platforms. The default passthrough group relays your stream as-is without re-encoding.'
             })}
@@ -449,7 +489,7 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
         />
 
         {/* Timestamp & Sync Settings */}
-        <div style={{ padding: '12px', backgroundColor: 'var(--bg-muted)', borderRadius: '8px' }}>
+        <div className="p-3 bg-bg-muted rounded-lg">
           <Toggle
             checked={formData.generatePts}
             onChange={(checked) => setFormData((prev) => ({ ...prev, generatePts: checked }))}
@@ -459,26 +499,12 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
         </div>
 
         {/* Video Settings Section */}
-        <div style={{ padding: '12px', backgroundColor: 'var(--bg-muted)', borderRadius: '8px' }}>
-          <div
-            style={{
-              marginBottom: '12px',
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              color: 'var(--text-primary)',
-            }}
-          >
+        <div className="p-3 bg-bg-muted rounded-lg">
+          <div className="mb-3 text-sm font-medium text-text-primary">
             {t('modals.videoSettings')}
           </div>
 
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: '12px',
-              marginBottom: '12px',
-            }}
-          >
+          <div className="grid grid-cols-2 gap-3 mb-3">
             <Select
               label={t('encoder.videoEncoder')}
               value={formData.videoCodec}
@@ -495,14 +521,7 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
             />
           </div>
 
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              gap: '12px',
-              marginBottom: '12px',
-            }}
-          >
+          <div className="grid grid-cols-3 gap-3 mb-3">
             <Select
               label={t('encoder.frameRate')}
               value={formData.fps}
@@ -535,13 +554,7 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
             disabled={!presetSupported}
           />
           {!presetSupported && (
-            <div
-              style={{
-                marginTop: '6px',
-                fontSize: '0.75rem',
-                color: 'var(--text-secondary)',
-              }}
-            >
+            <div className="mt-1.5 text-xs text-text-secondary">
               {tDynamic('encoder.presetUnsupported', {
                 defaultValue: 'Presets are not available for this encoder.',
               })}
@@ -562,26 +575,12 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
         </div>
 
         {/* Audio Settings Section */}
-        <div style={{ padding: '12px', backgroundColor: 'var(--bg-muted)', borderRadius: '8px' }}>
-          <div
-            style={{
-              marginBottom: '12px',
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              color: 'var(--text-primary)',
-            }}
-          >
+        <div className="p-3 bg-bg-muted rounded-lg">
+          <div className="mb-3 text-sm font-medium text-text-primary">
             {t('modals.audioSettings')}
           </div>
 
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: '12px',
-              marginBottom: '12px',
-            }}
-          >
+          <div className="grid grid-cols-2 gap-3 mb-3">
             <Select
               label={t('modals.audioCodec')}
               value={formData.audioCodec}
@@ -598,7 +597,7 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
             />
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+          <div className="grid grid-cols-2 gap-3">
             <Select
               label={t('modals.audioChannels')}
               value={formData.audioChannels}
@@ -616,15 +615,8 @@ export function OutputGroupModal({ open, onClose, mode, group }: OutputGroupModa
         </div>
 
         {/* Container Settings Section */}
-        <div style={{ padding: '12px', backgroundColor: 'var(--bg-muted)', borderRadius: '8px' }}>
-          <div
-            style={{
-              marginBottom: '12px',
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              color: 'var(--text-primary)',
-            }}
-          >
+        <div className="p-3 bg-bg-muted rounded-lg">
+          <div className="mb-3 text-sm font-medium text-text-primary">
             {t('modals.containerSettings')}
           </div>
 

--- a/apps/web/src/components/modals/PasswordModal.tsx
+++ b/apps/web/src/components/modals/PasswordModal.tsx
@@ -74,9 +74,9 @@ export function PasswordModal({
     <Modal open={open} onClose={onClose} title={title}>
       <form onSubmit={handleSubmit}>
         <ModalBody>
-          <div className="flex items-center gap-3 mb-4 p-3 bg-[var(--bg-muted)] rounded-lg">
-            <Lock className="w-5 h-5 text-[var(--primary)]" />
-            <p className="text-sm text-[var(--text-secondary)]">{description}</p>
+          <div className="flex items-center gap-3 mb-4 p-3 bg-bg-muted rounded-lg">
+            <Lock className="w-5 h-5 text-primary" />
+            <p className="text-sm text-text-secondary">{description}</p>
           </div>
 
           <div className="space-y-4">
@@ -97,7 +97,7 @@ export function PasswordModal({
                 onClick={() => setShowPassword(!showPassword)}
                 aria-label={showPassword ? t('common.hidePassword') : t('common.showPassword')}
                 aria-pressed={showPassword}
-                className="absolute right-3 top-[34px] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
+                className="absolute right-3 top-[34px] text-text-tertiary hover:text-text-primary transition-colors"
               >
                 {showPassword ? (
                   <EyeOff className="w-4 h-4" aria-hidden="true" />
@@ -118,13 +118,13 @@ export function PasswordModal({
             )}
 
             {displayError && (
-              <div className="p-3 bg-[var(--error-subtle)] border border-[var(--error-border)] rounded-lg">
-                <p className="text-sm text-[var(--error-text)]">{displayError}</p>
+              <div className="p-3 bg-error-subtle border border-error-border rounded-lg">
+                <p className="text-sm text-error-text">{displayError}</p>
               </div>
             )}
 
             {mode === 'encrypt' && (
-              <div className="text-xs text-[var(--text-tertiary)]">
+              <div className="text-xs text-text-tertiary">
                 <p className="font-medium mb-1">{t('modals.passwordRequirements')}:</p>
                 <ul className="list-disc list-inside space-y-0.5">
                   <li>{t('modals.passwordReq8Chars')}</li>

--- a/apps/web/src/components/modals/ProfileModal.tsx
+++ b/apps/web/src/components/modals/ProfileModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Lock, Eye, EyeOff } from 'lucide-react';
+import { cn } from '@/lib/cn';
 import { Modal } from '@/components/ui/Modal';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
@@ -237,7 +238,7 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
         </>
       }
     >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div className="flex flex-col gap-4">
         <Input
           label={t('modals.profileName')}
           placeholder={t('modals.profileNamePlaceholder')}
@@ -247,18 +248,11 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
         />
 
         {/* RTMP Input Configuration */}
-        <div style={{ padding: '12px', backgroundColor: 'var(--bg-muted)', borderRadius: '8px' }}>
-          <div
-            style={{
-              marginBottom: '12px',
-              fontSize: '0.875rem',
-              fontWeight: 500,
-              color: 'var(--text-primary)',
-            }}
-          >
+        <div className="p-3 bg-bg-muted rounded-lg">
+          <div className="mb-3 text-sm font-medium text-text-primary">
             {t('modals.rtmpInputSettings')}
           </div>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 100px 1fr', gap: '12px' }}>
+          <div className="grid grid-cols-[1fr_100px_1fr] gap-3">
             <Input
               label={t('modals.bindAddress')}
               placeholder={t('modals.bindAddressPlaceholder')}
@@ -284,19 +278,11 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
               helper={t('modals.applicationHelper')}
             />
           </div>
-          <div style={{ marginTop: '8px', fontSize: '0.75rem', color: 'var(--text-tertiary)' }}>
+          <div className="mt-2 text-xs text-text-tertiary">
             {t('modals.rtmpUrlPreview')}: rtmp://{formData.bindAddress}:{formData.port}/
             {formData.application}
           </div>
-          <div style={{
-            marginTop: '8px',
-            padding: '8px',
-            backgroundColor: 'var(--bg-base)',
-            borderRadius: '4px',
-            fontSize: '0.75rem',
-            color: 'var(--text-secondary)',
-            lineHeight: '1.5'
-          }}>
+          <div className="mt-2 p-2 bg-bg-base rounded text-xs text-text-secondary leading-normal">
             {tDynamic('modals.profileExplanation', {
               defaultValue: 'Configure your streaming software (OBS, etc.) to send to this RTMP URL. Encoding settings are configured in your streaming software, not in the profile. Use output groups to re-encode to different settings for different platforms.'
             })}
@@ -305,11 +291,11 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
 
         {/* Password Protection (only for create mode) */}
         {mode === 'create' && (
-          <div style={{ padding: '12px', backgroundColor: 'var(--bg-muted)', borderRadius: '8px' }}>
-            <div className="flex items-center justify-between" style={{ marginBottom: formData.usePassword ? '12px' : '0' }}>
+          <div className="p-3 bg-bg-muted rounded-lg">
+            <div className={cn('flex items-center justify-between', formData.usePassword && 'mb-3')}>
               <div className="flex items-center gap-2">
-                <Lock className="w-4 h-4 text-[var(--primary)]" />
-                <span style={{ fontSize: '0.875rem', fontWeight: 500, color: 'var(--text-primary)' }}>
+                <Lock className="w-4 h-4 text-primary" />
+                <span className="text-sm font-medium text-text-primary">
                   {t('profiles.protectWithPassword')}
                 </span>
               </div>
@@ -330,7 +316,7 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
             </div>
 
             {formData.usePassword && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div className="flex flex-col gap-3">
                 <div className="relative">
                   <Input
                     label={t('modals.password.password')}
@@ -344,8 +330,7 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-[34px] text-[var(--text-tertiary)] hover:text-[var(--text-primary)] transition-colors"
-                    style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '4px' }}
+                    className="absolute right-3 top-[34px] bg-transparent border-none cursor-pointer p-1 text-text-tertiary hover:text-text-primary transition-colors"
                   >
                     {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                   </button>
@@ -361,9 +346,9 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
                   autoComplete="new-password"
                 />
 
-                <div style={{ fontSize: '0.75rem', color: 'var(--text-tertiary)' }}>
-                  <p style={{ fontWeight: 500, marginBottom: '4px' }}>{t('modals.passwordRequirements')}:</p>
-                  <ul style={{ margin: 0, paddingLeft: '16px' }}>
+                <div className="text-xs text-text-tertiary">
+                  <p className="font-medium mb-1">{t('modals.passwordRequirements')}:</p>
+                  <ul className="m-0 pl-4">
                     <li>{t('modals.passwordReq8Chars')}</li>
                     <li>{t('modals.passwordReqNoRecovery')}</li>
                   </ul>
@@ -405,18 +390,18 @@ export function ProfileModal({ open, onClose, mode, profile }: ProfileModalProps
         }
       >
         <div className="space-y-3">
-          <p className="text-[var(--text-secondary)]">
+          <p className="text-text-secondary">
             {tDynamic('modals.portConflictBody', {
               defaultValue:
                 'Another profile is already configured to use this port. Only one profile can listen on a port at a time.'
             })}
           </p>
           {portConflictMessage && (
-            <div className="p-3 rounded-lg bg-[var(--warning-subtle)] border border-[var(--warning-border)] text-[var(--warning-text)] text-sm">
+            <div className="p-3 rounded-lg bg-warning-subtle border border-warning-border text-warning-text text-sm">
               {portConflictMessage}
             </div>
           )}
-          <p className="text-[var(--text-secondary)]">
+          <p className="text-text-secondary">
             {tDynamic('modals.portConflictConfirm', {
               defaultValue: 'Do you want to save anyway?'
             })}

--- a/apps/web/src/components/modals/TargetModal.tsx
+++ b/apps/web/src/components/modals/TargetModal.tsx
@@ -185,7 +185,7 @@ export function TargetModal({ open, onClose, mode, groupId, target }: TargetModa
         </>
       }
     >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div className="flex flex-col gap-4">
         {/* Output Group Selector */}
         <Select
           label={t('modals.outputGroupLabel')}
@@ -224,7 +224,7 @@ export function TargetModal({ open, onClose, mode, groupId, target }: TargetModa
           helper={`${t('modals.default')}: ${platformConfig[formData.service].defaultServer}`}
         />
 
-        <div style={{ position: 'relative' }}>
+        <div className="relative">
           <Input
             label={t('targets.streamKey')}
             type={showStreamKey ? 'text' : 'password'}
@@ -240,17 +240,7 @@ export function TargetModal({ open, onClose, mode, groupId, target }: TargetModa
             onClick={() => setShowStreamKey(!showStreamKey)}
             aria-label={showStreamKey ? t('common.hideStreamKey') : t('common.showStreamKey')}
             aria-pressed={showStreamKey}
-            style={{
-              position: 'absolute',
-              right: '12px',
-              top: '32px',
-              background: 'transparent',
-              border: 'none',
-              cursor: 'pointer',
-              color: 'var(--text-tertiary)',
-              fontSize: '12px',
-              padding: '4px 8px',
-            }}
+            className="absolute right-3 top-8 bg-transparent border-none cursor-pointer text-text-tertiary text-xs py-1 px-2 hover:text-text-primary transition-colors"
           >
             {showStreamKey ? t('common.hide') : t('common.show')}
           </button>

--- a/apps/web/src/components/navigation/NavBadge.tsx
+++ b/apps/web/src/components/navigation/NavBadge.tsx
@@ -9,15 +9,12 @@ export function NavBadge({ count, className }: NavBadgeProps) {
   return (
     <span
       className={cn(
-        'bg-[var(--primary)]',
+        'bg-primary text-primary-foreground',
         'text-tiny font-semibold',
         'rounded-full min-w-[20px] text-center',
+        'py-0.5 px-2',
         className
       )}
-      style={{
-        padding: '2px 8px',
-        color: 'var(--primary-foreground)',
-      }}
     >
       {count > 99 ? '99+' : count}
     </span>

--- a/apps/web/src/components/navigation/NavItem.tsx
+++ b/apps/web/src/components/navigation/NavItem.tsx
@@ -19,12 +19,12 @@ export function NavItem({ icon, label, active, badge, onClick, className }: NavI
         'text-sm font-medium transition-all duration-150',
         'border-none bg-transparent text-left cursor-pointer',
         active
-          ? 'bg-[var(--primary-subtle)] text-[var(--primary)]'
-          : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]',
-        'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring-default)]',
+          ? 'bg-primary-subtle text-primary'
+          : 'text-text-secondary hover:bg-bg-hover hover:text-text-primary',
+        'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring-default',
+        'py-2.5 px-3',
         className
       )}
-      style={{ padding: '10px 12px' }}
     >
       <span className="w-5 h-5 flex items-center justify-center">{icon}</span>
       <span className="flex-1">{label}</span>

--- a/apps/web/src/components/navigation/NavSection.tsx
+++ b/apps/web/src/components/navigation/NavSection.tsx
@@ -8,17 +8,17 @@ export interface NavSectionProps {
 
 export function NavSection({ title, children, className }: NavSectionProps) {
   return (
-    <div className={className} style={{ marginBottom: '24px' }}>
+    <div className={cn('mb-6', className)}>
       <div
         className={cn(
           'text-tiny font-semibold uppercase tracking-wider',
-          'text-[var(--text-tertiary)]'
+          'text-text-tertiary',
+          'px-3 mb-2'
         )}
-        style={{ padding: '0 12px', marginBottom: '8px' }}
       >
         {title}
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>{children}</div>
+      <div className="flex flex-col gap-1">{children}</div>
     </div>
   );
 }

--- a/apps/web/src/components/settings/FFmpegDownloadProgress.tsx
+++ b/apps/web/src/components/settings/FFmpegDownloadProgress.tsx
@@ -110,12 +110,12 @@ export function FFmpegDownloadProgress({
     return (
       <div className={cn('space-y-2', className)}>
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2 text-sm text-[var(--success-text)]">
+          <div className="flex items-center gap-2 text-sm text-success-text">
             <CheckCircle className="w-4 h-4" />
             <span>
               {t('settings.ffmpegInstalled')}
               {displayVersion && (
-                <span className="text-[var(--text-secondary)]">
+                <span className="text-text-secondary">
                   {' '}(v{displayVersion.replace(/^ffmpeg\s+version\s+/i, '').split(' ')[0]})
                 </span>
               )}
@@ -125,7 +125,7 @@ export function FFmpegDownloadProgress({
             variant="ghost"
             size="sm"
             onClick={() => setShowDeleteConfirm(true)}
-            className="text-[var(--text-tertiary)] hover:text-[var(--error-text)]"
+            className="text-text-tertiary hover:text-error-text"
           >
             <Trash2 className="w-4 h-4" />
           </Button>
@@ -133,8 +133,8 @@ export function FFmpegDownloadProgress({
 
         {/* Delete confirmation */}
         {showDeleteConfirm && (
-          <div className="p-3 rounded-lg bg-[var(--error-subtle)] border border-[var(--error-border)]">
-            <p className="text-sm text-[var(--text-secondary)] mb-3">
+          <div className="p-3 rounded-lg bg-error-subtle border border-error-border">
+            <p className="text-sm text-text-secondary mb-3">
               {t('settings.deleteFFmpegConfirm')}
             </p>
             <div className="flex gap-2">
@@ -158,7 +158,7 @@ export function FFmpegDownloadProgress({
         )}
 
         {versionCheckUnsupported && !showDeleteConfirm && (
-          <div className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
+          <div className="flex items-center gap-2 text-xs text-text-tertiary">
             <AlertCircle className="w-3 h-3" />
             <span>{t('settings.ffmpegVersionUnavailable')}</span>
           </div>
@@ -166,14 +166,14 @@ export function FFmpegDownloadProgress({
 
         {/* Update available notification */}
         {hasUpdate && versionInfo && !showDeleteConfirm && (
-          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-[var(--warning-subtle)] border border-[var(--warning-border)]">
+          <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-warning-subtle border border-warning-border">
             <div className="flex items-center gap-2">
-              <RefreshCw className="w-4 h-4 text-[var(--warning-text)]" />
+              <RefreshCw className="w-4 h-4 text-warning-text" />
               <div className="text-sm">
-                <span className="font-medium text-[var(--warning-text)]">
+                <span className="font-medium text-warning-text">
                   {t('settings.updateAvailable')}
                 </span>
-                <span className="text-[var(--text-secondary)] ml-2">
+                <span className="text-text-secondary ml-2">
                   {versionInfo.installed_version} {'->'} {versionInfo.latest_version}
                 </span>
               </div>
@@ -187,7 +187,7 @@ export function FFmpegDownloadProgress({
 
         {/* Checking for updates indicator */}
         {isCheckingVersion && !showDeleteConfirm && (
-          <div className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
+          <div className="flex items-center gap-2 text-xs text-text-tertiary">
             <Loader2 className="w-3 h-3 animate-spin" />
             <span>{t('settings.checkingForUpdates')}</span>
           </div>
@@ -200,7 +200,7 @@ export function FFmpegDownloadProgress({
   if (isDeleting) {
     return (
       <div className={cn('space-y-3', className)}>
-        <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+        <div className="flex items-center gap-2 text-sm text-text-secondary">
           <Loader2 className="w-4 h-4 animate-spin" />
           <span>{t('settings.deletingFFmpeg')}</span>
         </div>
@@ -212,7 +212,7 @@ export function FFmpegDownloadProgress({
   if (error && !isDownloading) {
     return (
       <div className={cn('space-y-3', className)}>
-        <div className="flex items-center gap-2 text-sm text-[var(--error-text)]">
+        <div className="flex items-center gap-2 text-sm text-error-text">
           <AlertCircle className="w-4 h-4" />
           <span>{error}</span>
         </div>
@@ -243,9 +243,9 @@ export function FFmpegDownloadProgress({
     return (
       <div className={cn('space-y-3', className)}>
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+          <div className="flex items-center gap-2 text-sm text-text-secondary">
             {isRequestingPermission ? (
-              <ShieldCheck className="w-4 h-4 text-[var(--primary)]" />
+              <ShieldCheck className="w-4 h-4 text-primary" />
             ) : (
               <Loader2 className="w-4 h-4 animate-spin" />
             )}
@@ -261,10 +261,10 @@ export function FFmpegDownloadProgress({
 
         {/* Show elevation hint early so user has time to read it */}
         {showElevationHint && (
-          <div className="p-3 rounded-lg bg-[var(--primary-muted)] border border-[var(--primary-subtle)]">
+          <div className="p-3 rounded-lg bg-primary-muted border border-primary-subtle">
             <div className="flex items-start gap-2">
-              <ShieldCheck className="w-4 h-4 text-[var(--primary)] mt-0.5 flex-shrink-0" />
-              <p className="text-xs text-[var(--text-secondary)]">
+              <ShieldCheck className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+              <p className="text-xs text-text-secondary">
                 {t('settings.elevationPromptHint')}
               </p>
             </div>
@@ -289,10 +289,10 @@ export function FFmpegDownloadProgress({
       <div className={cn('space-y-3', className)}>
         {/* Show elevation hint on Windows before download starts */}
         {isWindows && (
-          <div className="p-3 rounded-lg bg-[var(--primary-muted)] border border-[var(--primary-subtle)]">
+          <div className="p-3 rounded-lg bg-primary-muted border border-primary-subtle">
             <div className="flex items-start gap-2">
-              <ShieldCheck className="w-4 h-4 text-[var(--primary)] mt-0.5 flex-shrink-0" />
-              <p className="text-xs text-[var(--text-secondary)]">
+              <ShieldCheck className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+              <p className="text-xs text-text-secondary">
                 {t('settings.elevationPromptHint')}
               </p>
             </div>
@@ -322,15 +322,15 @@ function ProgressBar({ percent, downloaded, total, phase }: ProgressBarProps) {
   return (
     <div className="space-y-1">
       {/* Progress bar */}
-      <div className="h-2 bg-[var(--bg-sunken)] rounded-full overflow-hidden">
+      <div className="h-2 bg-bg-sunken rounded-full overflow-hidden">
         <div
-          className="h-full bg-[var(--primary)] rounded-full transition-all duration-300"
+          className="h-full bg-primary rounded-full transition-all duration-300"
           style={{ width: `${Math.min(percent, 100)}%` }}
         />
       </div>
 
       {/* Progress text */}
-      <div className="flex items-center justify-between text-xs text-[var(--text-tertiary)]">
+      <div className="flex items-center justify-between text-xs text-text-tertiary">
         {showBytes ? (
           <>
             <span>{formatBytes(downloaded)}</span>

--- a/apps/web/src/components/settings/KeyRotationSection.tsx
+++ b/apps/web/src/components/settings/KeyRotationSection.tsx
@@ -86,16 +86,16 @@ export function KeyRotationSection({ encryptStreamKeys, disabled = false }: KeyR
 
   return (
     <>
-      <div className="flex items-center justify-between" style={{ padding: '8px 0', gap: '12px' }}>
+      <div className="flex items-center justify-between py-2 gap-3">
         <div>
-          <div className="text-sm font-medium text-[var(--text-primary)]">
+          <div className="text-sm font-medium text-text-primary">
             {t('settings.machineKey')}
           </div>
-          <div className="text-xs text-[var(--text-tertiary)]">
+          <div className="text-xs text-text-tertiary">
             {t('settings.lastRotated', { timestamp: lastRotatedLabel })}
           </div>
           {!encryptStreamKeys && (
-            <div className="text-xs text-[var(--text-tertiary)]">
+            <div className="text-xs text-text-tertiary">
               {t('settings.rotationEncryptionOffHint')}
             </div>
           )}

--- a/apps/web/src/components/stream/OutputGroup.tsx
+++ b/apps/web/src/components/stream/OutputGroup.tsx
@@ -30,28 +30,28 @@ export function OutputGroup({
   return (
     <div
       className={cn(
-        'bg-[var(--bg-muted)] border border-[var(--border-default)]',
+        'bg-bg-muted border border-border-default',
         'rounded-xl',
+        'mb-4',
         className
       )}
-      style={{ marginBottom: '16px' }}
     >
       <button
         className={cn(
           'w-full flex items-center justify-between cursor-pointer',
           'bg-transparent border-none text-left',
-          'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring-default)]',
-          'focus-visible:ring-inset rounded-xl'
+          'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring-default',
+          'focus-visible:ring-inset rounded-xl',
+          'py-4 px-5'
         )}
-        style={{ padding: '16px 20px' }}
         onClick={() => setExpanded(!expanded)}
         aria-expanded={expanded}
       >
         <div className="flex items-center gap-3">
-          <Layers className="w-[18px] h-[18px] text-[var(--primary)]" />
+          <Layers className="w-[18px] h-[18px] text-primary" />
           <div>
-            <div className="font-semibold text-[var(--text-primary)]">{name}</div>
-            <div className="text-small text-[var(--text-secondary)]">{info}</div>
+            <div className="font-semibold text-text-primary">{name}</div>
+            <div className="text-small text-text-secondary">{info}</div>
           </div>
         </div>
         <div className="flex items-center gap-3">
@@ -62,13 +62,13 @@ export function OutputGroup({
           />
           <ChevronDown
             className={cn(
-              'w-[18px] h-[18px] text-[var(--text-tertiary)] transition-transform duration-200',
+              'w-[18px] h-[18px] text-text-tertiary transition-transform duration-200',
               expanded && 'rotate-180'
             )}
           />
         </div>
       </button>
-      {expanded && <div style={{ padding: '0 20px 20px 20px' }}>{children}</div>}
+      {expanded && <div className="px-5 pb-5">{children}</div>}
     </div>
   );
 }

--- a/apps/web/src/components/stream/OutputGroupCard.tsx
+++ b/apps/web/src/components/stream/OutputGroupCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Pencil, Copy, Trash2, Video, Volume2, Box, Plus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/cn';
@@ -21,7 +22,7 @@ export interface OutputGroupCardProps {
   className?: string;
 }
 
-export function OutputGroupCard({
+export const OutputGroupCard = memo(function OutputGroupCard({
   group,
   index,
   status,
@@ -46,13 +47,13 @@ export function OutputGroupCard({
   return (
     <Card className={cn('transition-all duration-150', className)}>
       <CardHeader>
-        <div className="flex items-center" style={{ gap: '12px' }}>
-          <h3 className={cn('font-semibold text-[var(--text-primary)]')}>
+        <div className="flex items-center gap-3">
+          <h3 className={cn('font-semibold text-text-primary')}>
             {group.name || t('outputs.defaultGroupName', { number: index + 1 })}
           </h3>
           <StreamStatus status={status} />
         </div>
-        <div className="flex items-center" style={{ gap: '8px' }}>
+        <div className="flex items-center gap-2">
           {onEdit && (
             <Button
               variant="ghost"
@@ -85,31 +86,31 @@ export function OutputGroupCard({
       </CardHeader>
       <CardBody>
         {/* Read-only display of nested settings - use Edit modal to change */}
-        <div className="flex flex-col" style={{ gap: '12px' }}>
+        <div className="flex flex-col gap-3">
           {/* Video Settings Summary */}
-          <div className="flex items-center text-sm" style={{ gap: '8px' }}>
-            <Video className="w-4 h-4 text-[var(--primary)]" />
-            <span className="text-[var(--text-secondary)]">{t('outputs.video')}:</span>
-            <span className="text-[var(--text-primary)]">{videoSummary}</span>
+          <div className="flex items-center text-sm gap-2">
+            <Video className="w-4 h-4 text-primary" />
+            <span className="text-text-secondary">{t('outputs.video')}:</span>
+            <span className="text-text-primary">{videoSummary}</span>
           </div>
 
           {/* Audio Settings Summary */}
-          <div className="flex items-center text-sm" style={{ gap: '8px' }}>
-            <Volume2 className="w-4 h-4 text-[var(--secondary)]" />
-            <span className="text-[var(--text-secondary)]">{t('outputs.audio')}:</span>
-            <span className="text-[var(--text-primary)]">{audioSummary}</span>
+          <div className="flex items-center text-sm gap-2">
+            <Volume2 className="w-4 h-4 text-secondary" />
+            <span className="text-text-secondary">{t('outputs.audio')}:</span>
+            <span className="text-text-primary">{audioSummary}</span>
           </div>
 
           {/* Container Settings Summary */}
-          <div className="flex items-center text-sm" style={{ gap: '8px' }}>
-            <Box className="w-4 h-4 text-[var(--accent)]" />
-            <span className="text-[var(--text-secondary)]">{t('outputs.container')}:</span>
-            <span className="text-[var(--text-primary)]">{containerSummary}</span>
+          <div className="flex items-center text-sm gap-2">
+            <Box className="w-4 h-4 text-accent" />
+            <span className="text-text-secondary">{t('outputs.container')}:</span>
+            <span className="text-text-primary">{containerSummary}</span>
           </div>
 
           {/* Stream Targets Section */}
-          <div className="flex items-center justify-between pt-2 border-t border-[var(--border-muted)]">
-            <div className="text-xs text-[var(--text-tertiary)]">
+          <div className="flex items-center justify-between pt-2 border-t border-border-muted">
+            <div className="text-xs text-text-tertiary">
               {group.streamTargets.length > 0
                 ? tDynamic('outputs.targetsCount', {
                     count: group.streamTargets.length,
@@ -124,7 +125,7 @@ export function OutputGroupCard({
                 onClick={onAddTarget}
                 aria-label={tDynamic('outputs.addTarget', { defaultValue: 'Add Target' })}
               >
-                <Plus className="w-3 h-3" style={{ marginRight: '4px' }} />
+                <Plus className="w-3 h-3 mr-1" />
                 {tDynamic('outputs.addTarget', { defaultValue: 'Add Target' })}
               </Button>
             )}
@@ -133,4 +134,4 @@ export function OutputGroupCard({
       </CardBody>
     </Card>
   );
-}
+});

--- a/apps/web/src/components/ui/Alert.tsx
+++ b/apps/web/src/components/ui/Alert.tsx
@@ -12,19 +12,19 @@ export interface AlertProps {
 
 const alertConfig = {
   info: {
-    wrapper: 'bg-[var(--primary-muted)] border-[var(--primary)] text-[var(--primary)]',
+    wrapper: 'bg-primary-muted border-primary text-primary',
     icon: Info,
   },
   success: {
-    wrapper: 'bg-[var(--success-subtle)] border-[var(--success-border)] text-[var(--success-text)]',
+    wrapper: 'bg-success-subtle border-success-border text-success-text',
     icon: CheckCircle,
   },
   warning: {
-    wrapper: 'bg-[var(--warning-subtle)] border-[var(--warning-border)] text-[var(--warning-text)]',
+    wrapper: 'bg-warning-subtle border-warning-border text-warning-text',
     icon: AlertTriangle,
   },
   error: {
-    wrapper: 'bg-[var(--error-subtle)] border-[var(--error-border)] text-[var(--error-text)]',
+    wrapper: 'bg-error-subtle border-error-border text-error-text',
     icon: XCircle,
   },
 };
@@ -34,8 +34,7 @@ export function Alert({ variant, title, children, className }: AlertProps) {
 
   return (
     <div
-      className={cn('rounded-lg border flex gap-3', wrapper, className)}
-      style={{ padding: '16px', marginBottom: '16px' }}
+      className={cn('rounded-lg border flex gap-3 p-4 mb-4', wrapper, className)}
       role="alert"
     >
       <Icon className="w-5 h-5 flex-shrink-0 mt-0.5" />

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -7,54 +7,47 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   loading?: boolean;
 }
 
+const VARIANT_CLASSES = {
+  primary:
+    'bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-active',
+  secondary:
+    'bg-secondary text-secondary-foreground hover:bg-secondary-hover active:bg-secondary-active',
+  accent:
+    'bg-accent text-accent-foreground hover:bg-accent-hover active:bg-accent-active',
+  ghost:
+    'bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary',
+  outline:
+    'bg-transparent border-2 border-primary text-primary hover:bg-primary-subtle',
+  destructive:
+    'bg-error text-error-foreground hover:bg-error-hover active:bg-error-hover',
+} as const;
+
+const SIZE_CLASSES = {
+  sm: 'text-sm h-9 py-2 px-5',
+  md: 'text-base h-11 py-2.5 px-6',
+  lg: 'text-lg h-14 py-3 px-10',
+  icon: 'w-10 h-10 p-0',
+} as const;
+
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     { className, variant = 'primary', size = 'md', loading, children, disabled, style, ...props },
     ref
   ) => {
-    const variants = {
-      primary:
-        '[background:var(--button-primary,var(--primary))] text-[var(--primary-foreground)] hover:[background:var(--button-primary-hover,var(--primary-hover))] active:[background:var(--button-primary-active,var(--primary-active))]',
-      secondary:
-        '[background:var(--button-secondary,var(--secondary))] text-[var(--secondary-foreground)] hover:[background:var(--button-secondary-hover,var(--secondary-hover))] active:[background:var(--button-secondary-active,var(--secondary-active))]',
-      accent:
-        '[background:var(--button-accent,var(--accent))] text-[var(--accent-foreground)] hover:[background:var(--button-accent-hover,var(--accent-hover))] active:[background:var(--button-accent-active,var(--accent-active))]',
-      ghost:
-        'bg-transparent text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]',
-      outline:
-        'bg-transparent border-2 border-[var(--primary)] text-[var(--primary)] hover:bg-[var(--primary-subtle)]',
-      destructive:
-        '[background:var(--button-destructive,var(--error))] text-[var(--error-foreground)] hover:[background:var(--button-destructive-hover,var(--error-hover))] active:[background:var(--button-destructive-active,var(--error-hover))]',
-    };
-
-    const sizeClasses = {
-      sm: 'text-sm',
-      md: 'text-base',
-      lg: 'text-lg',
-      icon: '',
-    };
-
-    const sizeStyles: Record<string, React.CSSProperties> = {
-      sm: { height: '36px', padding: '8px 20px' },
-      md: { height: '44px', padding: '10px 24px' },
-      lg: { height: '56px', padding: '12px 40px' },
-      icon: { width: '40px', height: '40px', padding: '0' },
-    };
-
     return (
       <button
         ref={ref}
         className={cn(
-          'inline-flex items-center justify-center font-semibold rounded-lg transition-all duration-150',
-          'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring-default)]',
-          'focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--ring-offset)]',
+          'inline-flex items-center justify-center gap-2 font-semibold rounded-lg transition-all duration-150',
+          'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring-default',
+          'focus-visible:ring-offset-2 focus-visible:ring-offset-ring-offset',
           'disabled:opacity-50 disabled:cursor-not-allowed',
           'border-none cursor-pointer',
-          variants[variant],
-          sizeClasses[size],
+          VARIANT_CLASSES[variant],
+          SIZE_CLASSES[size],
           className
         )}
-        style={{ gap: '8px', ...sizeStyles[size], ...style }}
+        style={style}
         disabled={disabled || loading}
         {...props}
       >

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -6,16 +6,16 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export function Card({ className, variant = 'default', ...props }: CardProps) {
   const variants = {
-    default: 'bg-[var(--bg-surface)] shadow-[var(--shadow-sm)]',
-    elevated: 'bg-[var(--bg-elevated)] shadow-[var(--shadow-md)]',
+    default: 'bg-bg-surface shadow-sm',
+    elevated: 'bg-bg-elevated shadow-md',
     interactive:
-      'bg-[var(--bg-surface)] shadow-[var(--shadow-sm)] hover:shadow-[var(--shadow-md)] hover:border-[var(--border-interactive)] cursor-pointer transition-all',
+      'bg-bg-surface shadow-sm hover:shadow-md hover:border-border-interactive cursor-pointer transition-all',
   };
 
   return (
     <div
       className={cn(
-        'rounded-xl border border-[var(--border-default)]',
+        'rounded-xl border border-border-default',
         variants[variant],
         className
       )}
@@ -30,11 +30,11 @@ export function CardHeader({ className, ...props }: CardHeaderProps) {
   return (
     <div
       className={cn(
-        'border-b border-[var(--border-muted)]',
+        'border-b border-border-muted',
         'flex items-center justify-between',
+        'py-5 px-6',
         className
       )}
-      style={{ padding: '20px 24px' }}
       {...props}
     />
   );
@@ -45,7 +45,7 @@ export interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement>
 export function CardTitle({ className, ...props }: CardTitleProps) {
   return (
     <h3
-      className={cn('text-base font-semibold text-[var(--text-primary)]', className)}
+      className={cn('text-base font-semibold text-text-primary', className)}
       {...props}
     />
   );
@@ -54,13 +54,13 @@ export function CardTitle({ className, ...props }: CardTitleProps) {
 export interface CardDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 export function CardDescription({ className, ...props }: CardDescriptionProps) {
-  return <p className={cn('text-sm text-[var(--text-secondary)] mt-1', className)} {...props} />;
+  return <p className={cn('text-sm text-text-secondary mt-1', className)} {...props} />;
 }
 
 export interface CardBodyProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function CardBody({ className, ...props }: CardBodyProps) {
-  return <div className={className} style={{ padding: '24px' }} {...props} />;
+  return <div className={cn('p-6', className)} {...props} />;
 }
 
 export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
@@ -69,11 +69,11 @@ export function CardFooter({ className, ...props }: CardFooterProps) {
   return (
     <div
       className={cn(
-        'border-t border-[var(--border-muted)] bg-[var(--bg-muted)] rounded-b-xl',
+        'border-t border-border-muted bg-bg-muted rounded-b-xl',
         'flex justify-end gap-3',
+        'py-4 px-6',
         className
       )}
-      style={{ padding: '16px 24px' }}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/ConnectionError.tsx
+++ b/apps/web/src/components/ui/ConnectionError.tsx
@@ -30,7 +30,7 @@ export function ConnectionError({
   const showDetails = Array.isArray(details) && details.length > 0;
 
   return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-[var(--bg-base)]">
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-bg-base">
       <div className="max-w-md w-full mx-4 text-center">
         {/* Logo */}
         <div className="flex justify-center mb-8">
@@ -39,13 +39,13 @@ export function ConnectionError({
 
         {/* Error Icon */}
         <div className="flex justify-center mb-6">
-          <div className="w-16 h-16 rounded-full bg-[var(--error-subtle)] flex items-center justify-center">
-            <AlertTriangle className="w-8 h-8 text-[var(--error)]" />
+          <div className="w-16 h-16 rounded-full bg-error-subtle flex items-center justify-center">
+            <AlertTriangle className="w-8 h-8 text-error" />
           </div>
         </div>
 
         {/* Title */}
-        <h1 className="text-xl font-semibold text-[var(--text-primary)] mb-2">
+        <h1 className="text-xl font-semibold text-text-primary mb-2">
           {title ??
             t('connection.errorTitle', {
               defaultValue: 'Cannot connect to server',
@@ -53,7 +53,7 @@ export function ConnectionError({
         </h1>
 
         {/* Description */}
-        <p className="text-[var(--text-secondary)] mb-4">
+        <p className="text-text-secondary mb-4">
           {description ??
             t('connection.errorDescription', {
               defaultValue: 'The backend server is not responding. Please ensure it is running and try again.',
@@ -61,20 +61,20 @@ export function ConnectionError({
         </p>
 
         {/* Server URL */}
-        <div className="mb-6 p-3 rounded-lg bg-[var(--bg-muted)] border border-[var(--border-default)]">
-          <p className="text-xs text-[var(--text-tertiary)] mb-1">
+        <div className="mb-6 p-3 rounded-lg bg-bg-muted border border-border-default">
+          <p className="text-xs text-text-tertiary mb-1">
             {t('connection.attemptingConnection', { defaultValue: 'Attempting to connect to:' })}
           </p>
-          <p className="text-sm font-mono text-[var(--text-primary)] break-all">{serverUrl}</p>
+          <p className="text-sm font-mono text-text-primary break-all">{serverUrl}</p>
         </div>
 
         {/* Details */}
         {showDetails ? (
-          <div className="mb-6 p-3 rounded-lg bg-[var(--bg-muted)] border border-[var(--border-default)] text-left">
-            <p className="text-xs text-[var(--text-tertiary)] mb-2">
+          <div className="mb-6 p-3 rounded-lg bg-bg-muted border border-border-default text-left">
+            <p className="text-xs text-text-tertiary mb-2">
               {t('connection.readinessDetails', { defaultValue: 'Readiness details:' })}
             </p>
-            <ul className="space-y-1 text-xs text-[var(--text-secondary)]">
+            <ul className="space-y-1 text-xs text-text-secondary">
               {details.map((detail, index) => (
                 <li key={`${detail}-${index}`} className="break-words">
                   {detail}
@@ -93,7 +93,7 @@ export function ConnectionError({
         </Button>
 
         {/* Help Text */}
-        <p className="mt-6 text-xs text-[var(--text-muted)]">
+        <p className="mt-6 text-xs text-text-muted">
           {helpText ??
             t('connection.helpText', {
               defaultValue: 'If the problem persists, check that the server is running and the URL is correct.',

--- a/apps/web/src/components/ui/ConnectionStatus.tsx
+++ b/apps/web/src/components/ui/ConnectionStatus.tsx
@@ -21,22 +21,22 @@ const statusConfig: Record<
 > = {
   connected: {
     icon: Wifi,
-    bgClass: 'bg-[var(--success-subtle)]',
-    textClass: 'text-[var(--success-text)]',
-    dotClass: 'bg-[var(--success)]',
+    bgClass: 'bg-success-subtle',
+    textClass: 'text-success-text',
+    dotClass: 'bg-success',
   },
   connecting: {
     icon: Loader2,
-    bgClass: 'bg-[var(--warning-subtle)]',
-    textClass: 'text-[var(--warning-text)]',
-    dotClass: 'bg-[var(--warning)]',
+    bgClass: 'bg-warning-subtle',
+    textClass: 'text-warning-text',
+    dotClass: 'bg-warning',
     animate: true,
   },
   disconnected: {
     icon: WifiOff,
-    bgClass: 'bg-[var(--error-subtle)]',
-    textClass: 'text-[var(--error-text)]',
-    dotClass: 'bg-[var(--error)]',
+    bgClass: 'bg-error-subtle',
+    textClass: 'text-error-text',
+    dotClass: 'bg-error',
   },
 };
 

--- a/apps/web/src/components/ui/Form.tsx
+++ b/apps/web/src/components/ui/Form.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/cn';
 export interface FormGroupProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function FormGroup({ className, ...props }: FormGroupProps) {
-  return <div className={className} style={{ marginBottom: '16px' }} {...props} />;
+  return <div className={cn('mb-4', className)} {...props} />;
 }
 
 export interface FormLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
@@ -11,8 +11,7 @@ export interface FormLabelProps extends React.LabelHTMLAttributes<HTMLLabelEleme
 export function FormLabel({ className, ...props }: FormLabelProps) {
   return (
     <label
-      className={cn('block text-sm font-medium text-[var(--text-primary)]', className)}
-      style={{ marginBottom: '6px' }}
+      className={cn('block text-sm font-medium text-text-primary mb-1.5', className)}
       {...props}
     />
   );
@@ -23,8 +22,7 @@ export interface FormHelperProps extends React.HTMLAttributes<HTMLParagraphEleme
 export function FormHelper({ className, ...props }: FormHelperProps) {
   return (
     <p
-      className={cn('text-xs text-[var(--text-tertiary)]', className)}
-      style={{ marginTop: '6px' }}
+      className={cn('text-xs text-text-tertiary mt-1.5', className)}
       {...props}
     />
   );
@@ -35,8 +33,7 @@ export interface FormErrorProps extends React.HTMLAttributes<HTMLParagraphElemen
 export function FormError({ className, ...props }: FormErrorProps) {
   return (
     <p
-      className={cn('text-xs text-[var(--error-text)]', className)}
-      style={{ marginTop: '6px' }}
+      className={cn('text-xs text-error-text mt-1.5', className)}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/Grid.tsx
+++ b/apps/web/src/components/ui/Grid.tsx
@@ -19,16 +19,16 @@ export function Grid({
     4: 'grid-cols-4 max-xl:grid-cols-2 max-md:grid-cols-1',
   };
 
-  const gapValues = {
-    sm: '12px',
-    md: '16px',
-    lg: '24px',
+  const gapClasses = {
+    sm: 'gap-3',
+    md: 'gap-4',
+    lg: 'gap-6',
   };
 
   return (
     <div
-      className={cn('grid', colStyles[cols], className)}
-      style={{ gap: gapValues[gap], ...style }}
+      className={cn('grid', colStyles[cols], gapClasses[gap], className)}
+      style={style}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -16,9 +16,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const describedBy = errorId || helperId;
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      <div className="flex flex-col gap-1.5">
         {label && (
-          <label htmlFor={inputId} className="block text-sm font-medium text-[var(--text-primary)]">
+          <label htmlFor={inputId} className="block text-sm font-medium text-text-primary">
             {label}
           </label>
         )}
@@ -30,26 +30,26 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           aria-describedby={describedBy}
           className={cn(
             'w-full text-sm rounded-lg transition-all duration-150',
-            'bg-[var(--bg-sunken)] text-[var(--text-primary)]',
-            'border-2 border-[var(--border-strong)]',
-            'placeholder:text-[var(--text-muted)]',
-            'hover:border-[var(--border-stronger)]',
-            'focus:outline-none focus:border-[var(--border-interactive)]',
-            'focus:ring-[3px] focus:ring-[var(--primary-muted)]',
-            'disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-[var(--bg-muted)]',
-            error && 'border-[var(--error-border)] focus:ring-[var(--error-subtle)]',
+            'bg-bg-sunken text-text-primary',
+            'border-2 border-border-strong',
+            'placeholder:text-text-muted',
+            'hover:border-border-stronger',
+            'focus:outline-none focus:border-border-interactive',
+            'focus:ring-[3px] focus:ring-primary-muted',
+            'disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-bg-muted',
+            error && 'border-error-border focus:ring-error-subtle',
+            'py-2.5 px-3.5',
             className
           )}
-          style={{ padding: '10px 14px' }}
           {...props}
         />
         {helper && !error && (
-          <p id={helperId} className="text-xs text-[var(--text-tertiary)]">
+          <p id={helperId} className="text-xs text-text-tertiary">
             {helper}
           </p>
         )}
         {error && (
-          <p id={errorId} className="text-xs text-[var(--error-text)]" role="alert">
+          <p id={errorId} className="text-xs text-error-text" role="alert">
             {error}
           </p>
         )}

--- a/apps/web/src/components/ui/Modal.tsx
+++ b/apps/web/src/components/ui/Modal.tsx
@@ -98,7 +98,7 @@ export function Modal({ open, onClose, title, children, footer, maxWidth = '500p
     <div
       className={cn(
         'fixed inset-0 z-[1000] flex items-center justify-center',
-        'bg-[var(--bg-overlay)]',
+        'bg-bg-overlay',
         'animate-in fade-in duration-200'
       )}
       onClick={(e) => closeOnBackdropClick && e.target === e.currentTarget && onClose()}
@@ -106,7 +106,7 @@ export function Modal({ open, onClose, title, children, footer, maxWidth = '500p
       <div
         ref={modalRef}
         className={cn(
-          'bg-[var(--bg-surface)] rounded-xl shadow-[var(--shadow-xl)]',
+          'bg-bg-surface rounded-xl shadow-xl',
           'w-full max-h-[90vh] overflow-hidden',
           'animate-in zoom-in-95 duration-200',
           'flex flex-col'
@@ -133,19 +133,18 @@ export function ModalHeader({ title, onClose }: ModalHeaderProps) {
   const { t } = useTranslation();
   return (
     <div
-      className="flex-shrink-0 border-b border-[var(--border-muted)] flex items-center justify-between"
-      style={{ padding: '20px 24px' }}
+      className="flex-shrink-0 border-b border-border-muted flex items-center justify-between py-5 px-6"
     >
-      <h3 id="modal-title" className="text-lg font-semibold text-[var(--text-primary)]">
+      <h3 id="modal-title" className="text-lg font-semibold text-text-primary">
         {title}
       </h3>
       <button
         onClick={onClose}
         className={cn(
           'w-8 h-8 flex items-center justify-center rounded-md',
-          'text-[var(--text-tertiary)] bg-transparent border-none cursor-pointer',
-          'hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]',
-          'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ring-default)]',
+          'text-text-tertiary bg-transparent border-none cursor-pointer',
+          'hover:bg-bg-hover hover:text-text-primary',
+          'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring-default',
           'transition-all duration-150'
         )}
         aria-label={t('common.close')}
@@ -163,7 +162,7 @@ interface ModalBodyProps {
 
 export function ModalBody({ children, className }: ModalBodyProps) {
   return (
-    <div className={cn('flex-1 min-h-0 overflow-y-auto', className)} style={{ padding: '24px' }}>
+    <div className={cn('flex-1 min-h-0 overflow-y-auto p-6', className)}>
       {children}
     </div>
   );
@@ -177,8 +176,7 @@ interface ModalFooterProps {
 export function ModalFooter({ children, className }: ModalFooterProps) {
   return (
     <div
-      className={cn('flex-shrink-0 border-t border-[var(--border-muted)] flex justify-end gap-3', className)}
-      style={{ padding: '16px 24px' }}
+      className={cn('flex-shrink-0 border-t border-border-muted flex justify-end gap-3 py-4 px-6', className)}
     >
       {children}
     </div>

--- a/apps/web/src/components/ui/Select.tsx
+++ b/apps/web/src/components/ui/Select.tsx
@@ -24,11 +24,11 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const describedBy = errorId || helperId;
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      <div className="flex flex-col gap-1.5">
         {label && (
           <label
             htmlFor={selectId}
-            className="block text-sm font-medium text-[var(--text-primary)]"
+            className="block text-sm font-medium text-text-primary"
           >
             {label}
           </label>
@@ -41,17 +41,17 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             aria-describedby={describedBy}
             className={cn(
               'w-full text-sm rounded-lg transition-all duration-150',
-              'bg-[var(--bg-sunken)] text-[var(--text-primary)]',
-              'border-2 border-[var(--border-strong)]',
-              'hover:border-[var(--border-stronger)]',
-              'focus:outline-none focus:border-[var(--border-interactive)]',
-              'focus:ring-[3px] focus:ring-[var(--primary-muted)]',
-              'disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-[var(--bg-muted)]',
+              'bg-bg-sunken text-text-primary',
+              'border-2 border-border-strong',
+              'hover:border-border-stronger',
+              'focus:outline-none focus:border-border-interactive',
+              'focus:ring-[3px] focus:ring-primary-muted',
+              'disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-bg-muted',
               'appearance-none cursor-pointer',
-              error && 'border-[var(--error-border)]',
+              error && 'border-error-border',
+              'py-2.5 pr-10 pl-3.5',
               className
             )}
-            style={{ padding: '10px 40px 10px 14px' }}
             {...props}
           >
             {options.map((option) => (
@@ -61,17 +61,17 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             ))}
           </select>
           <ChevronDown
-            className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-tertiary)] pointer-events-none"
+            className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-tertiary pointer-events-none"
             aria-hidden="true"
           />
         </div>
         {helper && !error && (
-          <p id={helperId} className="text-xs text-[var(--text-tertiary)]">
+          <p id={helperId} className="text-xs text-text-tertiary">
             {helper}
           </p>
         )}
         {error && (
-          <p id={errorId} className="text-xs text-[var(--error-text)]" role="alert">
+          <p id={errorId} className="text-xs text-error-text" role="alert">
             {error}
           </p>
         )}

--- a/apps/web/src/components/ui/StreamStatus.tsx
+++ b/apps/web/src/components/ui/StreamStatus.tsx
@@ -11,27 +11,27 @@ export interface StreamStatusProps {
 
 const statusStyles = {
   live: {
-    bg: 'bg-[var(--status-live-bg)]',
-    text: 'text-[var(--status-live-text)]',
-    dot: 'bg-[var(--status-live)]',
+    bg: 'bg-status-live-bg',
+    text: 'text-status-live-text',
+    dot: 'bg-status-live',
     pulse: true,
   },
   connecting: {
-    bg: 'bg-[var(--status-connecting-bg)]',
-    text: 'text-[var(--status-connecting-text)]',
-    dot: 'bg-[var(--status-connecting)]',
+    bg: 'bg-status-connecting-bg',
+    text: 'text-status-connecting-text',
+    dot: 'bg-status-connecting',
     pulse: true,
   },
   offline: {
-    bg: 'bg-[var(--status-offline-bg)]',
-    text: 'text-[var(--status-offline-text)]',
-    dot: 'bg-[var(--status-offline)]',
+    bg: 'bg-status-offline-bg',
+    text: 'text-status-offline-text',
+    dot: 'bg-status-offline',
     pulse: false,
   },
   error: {
-    bg: 'bg-[var(--error-subtle)]',
-    text: 'text-[var(--error-text)]',
-    dot: 'bg-[var(--error)]',
+    bg: 'bg-error-subtle',
+    text: 'text-error-text',
+    dot: 'bg-error',
     pulse: false,
   },
 };
@@ -52,12 +52,11 @@ export function StreamStatus({ status, label, showPulse = true, className }: Str
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-full text-xs font-medium',
+        'inline-flex items-center gap-1.5 rounded-full text-xs font-medium py-1 px-2.5',
         styles.bg,
         styles.text,
         className
       )}
-      style={{ padding: '4px 10px' }}
     >
       <span
         className={cn('w-1.5 h-1.5 rounded-full', styles.dot, shouldPulse && 'animate-pulse')}

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -12,9 +12,9 @@ function ToastItem({ toast }: { toast: ToastType }) {
   };
 
   const styles = {
-    success: 'bg-[var(--success-subtle)] border-[var(--success-border)] text-[var(--success-text)]',
-    error: 'bg-[var(--error-subtle)] border-[var(--error-border)] text-[var(--error-text)]',
-    info: 'bg-[var(--primary-muted)] border-[var(--primary)] text-[var(--primary)]',
+    success: 'bg-success-subtle border-success-border text-success-text',
+    error: 'bg-error-subtle border-error-border text-error-text',
+    info: 'bg-primary-muted border-primary text-primary',
   };
 
   return (

--- a/apps/web/src/components/ui/Toggle.tsx
+++ b/apps/web/src/components/ui/Toggle.tsx
@@ -27,11 +27,10 @@ export function Toggle({
   return (
     <label
       className={cn(
-        'inline-flex items-center cursor-pointer',
+        'inline-flex items-center gap-3 cursor-pointer',
         disabled && 'opacity-50 cursor-not-allowed',
         className
       )}
-      style={{ gap: '12px' }}
     >
       <span className="relative w-11 h-6 flex-shrink-0">
         <input
@@ -48,16 +47,16 @@ export function Toggle({
         <span
           className={cn(
             'absolute inset-0 rounded-full transition-colors duration-200',
-            'bg-[var(--border-strong)]',
-            'peer-checked:bg-[var(--primary)]',
-            'peer-focus-visible:ring-[3px] peer-focus-visible:ring-[var(--ring-default)]',
-            'peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-[var(--ring-offset)]'
+            'bg-border-strong',
+            'peer-checked:bg-primary',
+            'peer-focus-visible:ring-[3px] peer-focus-visible:ring-ring-default',
+            'peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-ring-offset'
           )}
         />
         <span
           className={cn(
             'absolute w-[18px] h-[18px] left-[3px] bottom-[3px]',
-            'bg-white rounded-full shadow-[var(--shadow-sm)]',
+            'bg-white rounded-full shadow-sm',
             'transition-transform duration-200',
             'peer-checked:translate-x-5'
           )}
@@ -65,9 +64,9 @@ export function Toggle({
       </span>
       {(label || description) && (
         <div className="flex flex-col">
-          {label && <span className="text-sm font-medium text-[var(--text-primary)]">{label}</span>}
+          {label && <span className="text-sm font-medium text-text-primary">{label}</span>}
           {description && (
-            <span id={descriptionId} className="text-xs text-[var(--text-tertiary)]">
+            <span id={descriptionId} className="text-xs text-text-tertiary">
               {description}
             </span>
           )}

--- a/apps/web/src/hooks/useChatListener.ts
+++ b/apps/web/src/hooks/useChatListener.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { events } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import { useChatStore } from '@/stores/chatStore';
 import type { ChatMessage } from '@/types/chat';
 import { CHAT_MESSAGE_EVENT, CHAT_OVERLAY_SETTINGS_EVENT } from '@/lib/chatEvents';
@@ -21,7 +22,7 @@ export function useChatListener() {
         unlistenMessages = unsubscribe;
       })
       .catch((error) => {
-        console.error('Failed to listen for chat messages:', error);
+        logger.error('Failed to listen for chat messages:', error);
       });
 
     events.on<{ transparent: boolean }>(CHAT_OVERLAY_SETTINGS_EVENT, (payload) => {
@@ -31,7 +32,7 @@ export function useChatListener() {
         unlistenOverlay = unsubscribe;
       })
       .catch((error) => {
-        console.error('Failed to listen for chat overlay settings:', error);
+        logger.error('Failed to listen for chat overlay settings:', error);
       });
 
     return () => {

--- a/apps/web/src/hooks/useFFmpegDownload.ts
+++ b/apps/web/src/hooks/useFFmpegDownload.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api, events } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import type { FFmpegVersionInfo } from '@/types/api';
 
 /**
@@ -114,7 +115,7 @@ export function useFFmpegDownload(): FFmpegDownloadState {
       setFFmpegPath(path);
       return path;
     } catch (err) {
-      console.error('Failed to check bundled FFmpeg:', err);
+      logger.error('Failed to check bundled FFmpeg:', err);
       return null;
     }
   }, []);
@@ -150,7 +151,7 @@ export function useFFmpegDownload(): FFmpegDownloadState {
       setIsDownloading(false);
       setProgress(null);
     } catch (err) {
-      console.error('Failed to cancel download:', err);
+      logger.error('Failed to cancel download:', err);
     }
   }, []);
 
@@ -181,7 +182,7 @@ export function useFFmpegDownload(): FFmpegDownloadState {
         setVersionInfo(info);
         return info;
       } catch (err) {
-        console.error('Failed to check for FFmpeg updates:', err);
+        logger.error('Failed to check for FFmpeg updates:', err);
         return null;
       } finally {
         setIsCheckingVersion(false);

--- a/apps/web/src/hooks/useLogListener.ts
+++ b/apps/web/src/hooks/useLogListener.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { api, events } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import { useLogStore } from '@/stores/logStore';
 import { createLogEntry, mapLogLevelFromNumber, parseLogLine } from '@/lib/logging';
 
@@ -25,7 +26,7 @@ export function useLogListener() {
         const entries = lines.map(parseLogLine);
         addLogs(entries);
       } catch (error) {
-        console.error('Failed to load recent logs:', error);
+        logger.error('Failed to load recent logs:', error);
       }
     };
 

--- a/apps/web/src/hooks/useObsEvents.ts
+++ b/apps/web/src/hooks/useObsEvents.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { events } from '@/lib/backend';
+import { logger } from '@/lib/logger';
+import { OBS_TRIGGER_DELAY_MS } from '@/lib/constants';
 import { useObsStore } from '@/stores/obsStore';
 import { useStreamStore } from '@/stores/streamStore';
 import { useProfileStore } from '@/stores/profileStore';
@@ -25,8 +27,8 @@ const INITIAL_RETRY_DELAY = 2000; // 2 seconds
 const MAX_RETRY_DELAY = 30000; // 30 seconds
 const RETRY_BACKOFF_MULTIPLIER = 1.5;
 
-// Delay before triggering SpiritStream when OBS starts streaming (ms)
-const OBS_TO_SPIRITSTREAM_DELAY_MS = 2000;
+// Delay before triggering SpiritStream when OBS starts streaming
+const OBS_TO_SPIRITSTREAM_DELAY_MS = OBS_TRIGGER_DELAY_MS;
 
 /**
  * Hook that listens for OBS WebSocket events and handles:
@@ -80,23 +82,23 @@ export function useObsEvents() {
       window.clearTimeout(retryTimeoutRef.current);
     }
 
-    console.log(`[useObsEvents] Scheduling retry in ${currentRetryDelay.current}ms`);
+    logger.debug(`[useObsEvents] Scheduling retry in ${currentRetryDelay.current}ms`);
 
     retryTimeoutRef.current = window.setTimeout(async () => {
       retryTimeoutRef.current = null;
 
       if (manuallyDisconnected.current) {
-        console.log('[useObsEvents] Skipping auto-connect - manually disconnected');
+        logger.debug('[useObsEvents] Skipping auto-connect - manually disconnected');
         return;
       }
 
       try {
-        console.log('[useObsEvents] Attempting OBS auto-connect...');
+        logger.debug('[useObsEvents] Attempting OBS auto-connect...');
         await connectRef.current(false); // false = not manual, this is auto-connect
         // Reset retry delay on successful connection
         currentRetryDelay.current = INITIAL_RETRY_DELAY;
       } catch (error) {
-        console.log('[useObsEvents] Auto-connect failed, will retry:', error);
+        logger.debug('[useObsEvents] Auto-connect failed, will retry:', error);
         scheduleRetry();
       }
     }, currentRetryDelay.current);
@@ -111,17 +113,17 @@ export function useObsEvents() {
   // Attempt to connect to OBS (isManual=false for auto-connect)
   const attemptConnect = useCallback(async () => {
     if (manuallyDisconnected.current) {
-      console.log('[useObsEvents] Skipping auto-connect - manually disconnected');
+      logger.debug('[useObsEvents] Skipping auto-connect - manually disconnected');
       return;
     }
 
     try {
-      console.log('[useObsEvents] Attempting OBS auto-connect...');
+      logger.debug('[useObsEvents] Attempting OBS auto-connect...');
       await connectRef.current(false); // false = not manual, this is auto-connect
       // Reset retry delay on successful connection
       currentRetryDelay.current = INITIAL_RETRY_DELAY;
     } catch (error) {
-      console.log('[useObsEvents] Auto-connect failed, will retry:', error);
+      logger.debug('[useObsEvents] Auto-connect failed, will retry:', error);
       scheduleRetry();
     }
   }, [scheduleRetry]);
@@ -201,7 +203,7 @@ export function useObsEvents() {
     const setupListeners = async () => {
       // Listen for OBS connection status changes
       unlistenStatus = await events.on<ObsStatusEvent>('obs://status', (payload) => {
-        console.log('[useObsEvents] Received obs://status:', payload);
+        logger.debug('[useObsEvents] Received obs://status:', payload);
 
         const connectionStatus: ObsConnectionStatus =
           payload.status === 'connecting' ? 'connecting' :
@@ -219,7 +221,7 @@ export function useObsEvents() {
 
       // Listen for OBS stream state changes
       unlistenStreamState = await events.on<ObsStreamStateEvent>('obs://stream_state', (payload) => {
-        console.log('[useObsEvents] Received obs://stream_state:', payload);
+        logger.debug('[useObsEvents] Received obs://stream_state:', payload);
 
         const newStatus = payload.status;
         const wasActive = prevStreamStatus.current === 'active';
@@ -231,7 +233,7 @@ export function useObsEvents() {
 
         // Skip if this change was triggered by us (SpiritStream -> OBS)
         if (triggeredByUs) {
-          console.log('[useObsEvents] Ignoring state change triggered by SpiritStream');
+          logger.debug('[useObsEvents] Ignoring state change triggered by SpiritStream');
           setTriggeredByUs(false);
           prevStreamStatus.current = newStatus;
           return;
@@ -248,16 +250,16 @@ export function useObsEvents() {
 
         // OBS started streaming -> Start SpiritStream
         if (!wasActive && isNowActive) {
-          console.log('[useObsEvents] OBS started streaming, triggering SpiritStream');
+          logger.info('[useObsEvents] OBS started streaming, triggering SpiritStream');
 
           if (!currentProfile) {
-            console.warn('[useObsEvents] No profile loaded, cannot start SpiritStream');
+            logger.warn('[useObsEvents] No profile loaded, cannot start SpiritStream');
             prevStreamStatus.current = newStatus;
             return;
           }
 
           if (isStreaming || activeGroups.size > 0) {
-            console.log('[useObsEvents] SpiritStream already streaming, skipping trigger');
+            logger.debug('[useObsEvents] SpiritStream already streaming, skipping trigger');
             prevStreamStatus.current = newStatus;
             return;
           }
@@ -268,7 +270,7 @@ export function useObsEvents() {
           );
 
           if (eligibleGroups.length === 0) {
-            console.warn('[useObsEvents] No eligible output groups to stream');
+            logger.warn('[useObsEvents] No eligible output groups to stream');
             prevStreamStatus.current = newStatus;
             return;
           }
@@ -280,23 +282,23 @@ export function useObsEvents() {
           // Add delay before starting SpiritStream to let OBS stabilize
           setTimeout(() => {
             startAllGroups(eligibleGroups, incomingUrl).catch((error) => {
-              console.error('[useObsEvents] Failed to start SpiritStream:', error);
+              logger.error('[useObsEvents] Failed to start SpiritStream:', error);
             });
           }, OBS_TO_SPIRITSTREAM_DELAY_MS);
         }
 
         // OBS stopped streaming -> Stop SpiritStream
         if (wasActive && isNowInactive) {
-          console.log('[useObsEvents] OBS stopped streaming, triggering SpiritStream stop');
+          logger.info('[useObsEvents] OBS stopped streaming, triggering SpiritStream stop');
 
           if (!isStreaming && activeGroups.size === 0) {
-            console.log('[useObsEvents] SpiritStream not streaming, skipping stop trigger');
+            logger.debug('[useObsEvents] SpiritStream not streaming, skipping stop trigger');
             prevStreamStatus.current = newStatus;
             return;
           }
 
           stopAllGroups().catch((error) => {
-            console.error('[useObsEvents] Failed to stop SpiritStream:', error);
+            logger.error('[useObsEvents] Failed to stop SpiritStream:', error);
           });
         }
 

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient, useIsMutating } from '@tanstack/react-query';
 import { useEffect, useCallback } from 'react';
 import { api } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import type { AppSettings } from '@/types/api';
 
 /**
@@ -122,7 +123,7 @@ export function useUpdateSetting() {
       if (context?.previousSettings) {
         queryClient.setQueryData(SETTINGS_QUERY_KEY, context.previousSettings);
       }
-      console.error('Failed to save setting:', err);
+      logger.error('Failed to save setting:', err);
     },
   });
 }
@@ -172,7 +173,7 @@ export function useSaveSettings() {
       if (context?.previousSettings) {
         queryClient.setQueryData(SETTINGS_QUERY_KEY, context.previousSettings);
       }
-      console.error('Failed to save settings:', err);
+      logger.error('Failed to save settings:', err);
     },
   });
 }

--- a/apps/web/src/lib/backend/env.ts
+++ b/apps/web/src/lib/backend/env.ts
@@ -1,3 +1,5 @@
+import { RETRY_BASE_DELAY_MS } from '@/lib/constants';
+
 /**
  * Backend communication mode.
  *
@@ -79,7 +81,7 @@ export async function safeFetch(
     // Retry logic for localhost - handles race condition with server startup
     // Increased retries to handle server warm-up time after health check passes
     const maxRetries = 5;
-    const baseDelay = 800; // ms
+    const baseDelay = RETRY_BASE_DELAY_MS;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {

--- a/apps/web/src/lib/backend/httpDialogs.ts
+++ b/apps/web/src/lib/backend/httpDialogs.ts
@@ -1,4 +1,5 @@
 import type { OpenFileOptions, SaveFileOptions, OpenTextResult, DialogFilter } from './dialogTypes';
+import { logger } from '@/lib/logger';
 import { getBackendBaseUrl, getAuthHeaders, safeFetch } from './env';
 
 type PickerAcceptType = { description?: string; accept: Record<string, string[]> };
@@ -135,7 +136,7 @@ export const dialogs = {
         if ((error as Error).name === 'AbortError') {
           throw error; // Re-throw to indicate user cancellation
         }
-        console.warn('[dialogs] File System Access API failed, falling back to download:', error);
+        logger.warn('[dialogs] File System Access API failed, falling back to download:', error);
         // Fall through to legacy download method
       }
     }
@@ -180,10 +181,10 @@ export const dialogs = {
 
         if (!response.ok) {
           const error = await response.text();
-          console.error('[dialogs] Failed to open path:', error);
+          logger.error('[dialogs] Failed to open path:', error);
         }
       } catch (error) {
-        console.error('[dialogs] Failed to open path:', error);
+        logger.error('[dialogs] Failed to open path:', error);
       }
     } else {
       // Use window.open for URLs

--- a/apps/web/src/lib/backend/httpEvents.ts
+++ b/apps/web/src/lib/backend/httpEvents.ts
@@ -1,4 +1,5 @@
 import { getBackendWsUrl } from './env';
+import { logger } from '@/lib/logger';
 import { useConnectionStore } from '@/stores/connectionStore';
 
 type Handler<T> = (payload: T) => void;
@@ -79,8 +80,8 @@ function ensureSocket(): Promise<void> {
     const isCrossOrigin = wsHost !== window.location.host;
 
     if (isCrossOrigin) {
-      // For cross-origin connections, include token in query params
-      // Backend supports both cookie auth and token query param
+      // SECURITY: localStorage token is a temporary measure for cross-origin WS auth.
+      // Migrate to httpOnly cookie auth when full auth system (Workstream E) lands.
       const token = window.localStorage.getItem('spiritstream-auth-token');
       if (token) {
         const separator = wsUrl.includes('?') ? '&' : '?';
@@ -112,7 +113,7 @@ function ensureSocket(): Promise<void> {
           handler(parsed.payload);
         }
       } catch (error) {
-        console.warn('Failed to parse backend event:', error);
+        logger.warn('Failed to parse backend event:', error);
       }
     });
 

--- a/apps/web/src/lib/chatWindow.ts
+++ b/apps/web/src/lib/chatWindow.ts
@@ -1,4 +1,6 @@
 import { isTauri } from './backend/env';
+import { logger } from '@/lib/logger';
+import { CHAT_POPUP_WIDTH, CHAT_POPUP_HEIGHT, CHAT_OVERLAY_POLL_MS } from '@/lib/constants';
 import { useChatStore } from '@/stores/chatStore';
 
 const CHAT_OVERLAY_LABEL = 'chat-overlay';
@@ -31,8 +33,8 @@ async function openTauriOverlay() {
 
   const overlay = new WebviewWindow(CHAT_OVERLAY_LABEL, {
     title: 'SpiritStream Chat',
-    width: 420,
-    height: 720,
+    width: CHAT_POPUP_WIDTH,
+    height: CHAT_POPUP_HEIGHT,
     resizable: true,
     decorations: false,
     transparent: true,
@@ -43,15 +45,15 @@ async function openTauriOverlay() {
 
   overlay.once('tauri://created', () => {
     overlay.show().catch((error) => {
-      console.error('Failed to show chat overlay window:', error);
+      logger.error('Failed to show chat overlay window:', error);
     });
     overlay.setFocus().catch((error) => {
-      console.error('Failed to focus chat overlay window:', error);
+      logger.error('Failed to focus chat overlay window:', error);
     });
   });
 
   overlay.once('tauri://error', (error) => {
-    console.error('Failed to create chat overlay window:', error);
+    logger.error('Failed to create chat overlay window:', error);
   });
 }
 
@@ -63,8 +65,8 @@ function openBrowserPopup() {
   }
 
   // Calculate center position
-  const width = 420;
-  const height = 720;
+  const width = CHAT_POPUP_WIDTH;
+  const height = CHAT_POPUP_HEIGHT;
   const left = window.screenX + (window.outerWidth - width) / 2;
   const top = window.screenY + (window.outerHeight - height) / 2;
 
@@ -75,7 +77,7 @@ function openBrowserPopup() {
   );
 
   if (!browserPopup) {
-    console.error('Failed to open chat popup - popup may be blocked');
+    logger.error('Failed to open chat popup - popup may be blocked');
   }
 }
 
@@ -87,7 +89,7 @@ export async function openChatOverlay() {
       openBrowserPopup();
     }
   } catch (error) {
-    console.error('Failed to open chat overlay window:', error);
+    logger.error('Failed to open chat overlay window:', error);
   }
 }
 
@@ -103,7 +105,7 @@ export async function closeChatOverlay() {
         await overlay.close();
       }
     } catch (error) {
-      console.error('Failed to close chat overlay:', error);
+      logger.error('Failed to close chat overlay:', error);
     }
   } else if (browserPopup && !browserPopup.closed) {
     browserPopup.close();
@@ -124,7 +126,7 @@ export async function setOverlayAlwaysOnTop(alwaysOnTop: boolean) {
       await overlay.setAlwaysOnTop(alwaysOnTop);
     }
   } catch (error) {
-    console.error('Failed to set always on top:', error);
+    logger.error('Failed to set always on top:', error);
   }
 }
 
@@ -174,8 +176,8 @@ export async function setupOverlayAutoClose() {
         clearInterval(checkInterval);
         overlayWindow.close().catch(() => {});
       }
-    }, 500);
+    }, CHAT_OVERLAY_POLL_MS);
   } catch (error) {
-    console.error('Failed to set up overlay auto-close:', error);
+    logger.error('Failed to set up overlay auto-close:', error);
   }
 }

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,0 +1,20 @@
+/** Delay before triggering SpiritStream when OBS starts streaming (ms). */
+export const OBS_TRIGGER_DELAY_MS = 2000;
+
+/** Auto-save debounce delay (ms). */
+export const AUTO_SAVE_DELAY_MS = 500;
+
+/** Polling interval for refreshing chat platform status (ms). */
+export const CHAT_POLL_INTERVAL_MS = 5000;
+
+/** Polling interval for chat overlay main-window existence check (ms). */
+export const CHAT_OVERLAY_POLL_MS = 500;
+
+/** Base delay for HTTP retry with exponential back-off (ms). */
+export const RETRY_BASE_DELAY_MS = 800;
+
+/** Default width for the chat popup / overlay window. */
+export const CHAT_POPUP_WIDTH = 420;
+
+/** Default height for the chat popup / overlay window. */
+export const CHAT_POPUP_HEIGHT = 720;

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -1,0 +1,20 @@
+/* eslint-disable no-console */
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LOG_LEVELS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+const currentLevel: LogLevel = import.meta.env.DEV ? 'debug' : 'warn';
+
+export const logger = {
+  debug: (...args: unknown[]) => {
+    if (LOG_LEVELS.debug >= LOG_LEVELS[currentLevel]) console.debug('[SS]', ...args);
+  },
+  info: (...args: unknown[]) => {
+    if (LOG_LEVELS.info >= LOG_LEVELS[currentLevel]) console.info('[SS]', ...args);
+  },
+  warn: (...args: unknown[]) => {
+    if (LOG_LEVELS.warn >= LOG_LEVELS[currentLevel]) console.warn('[SS]', ...args);
+  },
+  error: (...args: unknown[]) => {
+    if (LOG_LEVELS.error >= LOG_LEVELS[currentLevel]) console.error('[SS]', ...args);
+  },
+};

--- a/apps/web/src/lib/notification.ts
+++ b/apps/web/src/lib/notification.ts
@@ -1,4 +1,5 @@
 import { isTauri } from '@/lib/platform';
+import { logger } from '@/lib/logger';
 import {
   isPermissionGranted,
   requestPermission,
@@ -26,6 +27,6 @@ export async function showSystemNotification(title: string, body: string) {
 
     await sendNotification({ title, body });
   } catch (err) {
-    console.warn('System notification failed:', err);
+    logger.warn('System notification failed:', err);
   }
 }

--- a/apps/web/src/stores/obsStore.ts
+++ b/apps/web/src/stores/obsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { api } from '@/lib/backend/httpApi';
+import { logger } from '@/lib/logger';
 import { showSystemNotification } from '@/lib/notification';
 import { useSettingsStore } from './settingsStore';
 import { useProfileStore } from './profileStore';
@@ -85,7 +86,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
         websocketVersion: state.websocketVersion,
       });
     } catch (error) {
-      console.error('Failed to load OBS state:', error);
+      logger.error('Failed to load OBS state:', error);
     }
   },
 
@@ -99,7 +100,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
       const config = await api.obs.getConfig();
       set({ config });
     } catch (error) {
-      console.error('Failed to load OBS config:', error);
+      logger.error('Failed to load OBS config:', error);
     } finally {
       set({ isLoading: false });
     }
@@ -125,7 +126,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
         direction: config.direction,
         autoConnect: config.autoConnect,
       }).catch((error) => {
-        console.error('Failed to sync OBS config to backend:', error);
+        logger.error('Failed to sync OBS config to backend:', error);
       });
     }
   },
@@ -138,7 +139,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
     const currentProfile = useProfileStore.getState().current;
 
     if (!currentConfig || !currentProfile?.settings) {
-      console.error('Cannot update OBS config: no config or profile loaded');
+      logger.error('Cannot update OBS config: no config or profile loaded');
       return;
     }
 
@@ -184,7 +185,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
         autoConnect: newConfig.autoConnect,
       });
     } catch (error) {
-      console.error('Failed to update OBS config:', error);
+      logger.error('Failed to update OBS config:', error);
       // Reload config from profile on error
       get().syncConfigFromProfile();
       throw error;
@@ -227,7 +228,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
         errorMessage: null,
       });
     } catch (error) {
-      console.error('Failed to disconnect from OBS:', error);
+      logger.error('Failed to disconnect from OBS:', error);
       throw error;
     }
   },
@@ -236,7 +237,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
     try {
       await api.obs.startStream();
     } catch (error) {
-      console.error('Failed to start OBS stream:', error);
+      logger.error('Failed to start OBS stream:', error);
       throw error;
     }
   },
@@ -245,7 +246,7 @@ export const useObsStore = create<ObsStoreState>((set, get) => ({
     try {
       await api.obs.stopStream();
     } catch (error) {
-      console.error('Failed to stop OBS stream:', error);
+      logger.error('Failed to stop OBS stream:', error);
       throw error;
     }
   },

--- a/apps/web/src/stores/profileStore.ts
+++ b/apps/web/src/stores/profileStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { api } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import i18n from '@/lib/i18n';
 import {
   type Profile,
@@ -115,7 +116,7 @@ const applyProfileSettings = async (settings: ProfileSettings) => {
     try {
       await obsStore.disconnect(false); // false = not manual, don't disable auto-reconnect permanently
     } catch (error) {
-      console.warn('Failed to disconnect OBS when switching profiles:', error);
+      logger.warn('Failed to disconnect OBS when switching profiles:', error);
     }
   }
 
@@ -128,7 +129,7 @@ const applyProfileSettings = async (settings: ProfileSettings) => {
     pendingObsAutoConnectTimeout = setTimeout(() => {
       pendingObsAutoConnectTimeout = null;
       useObsStore.getState().connect(false).catch((error) => {
-        console.warn('Failed to auto-connect to OBS:', error);
+        logger.warn('Failed to auto-connect to OBS:', error);
       });
     }, 100);
   }
@@ -218,7 +219,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
       }
 
       const profile = await api.profile.load(name, password);
-      console.log('[ProfileStore] Profile loaded from backend:', {
+      logger.debug('[ProfileStore] Profile loaded from backend:', {
         profileId: profile.id,
         profileName: profile.name,
       });
@@ -249,7 +250,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
           await api.settings.save({ ...settings, lastProfile: name });
         }
       } catch (settingsError) {
-        console.warn('[ProfileStore] Failed to save last profile:', settingsError);
+        logger.warn('[ProfileStore] Failed to save last profile:', settingsError);
       }
     } catch (error) {
       const errorMsg = String(error);
@@ -288,7 +289,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
         await get().loadProfiles();
         set({ pendingUnlock: false });
       } catch (error) {
-        console.error('[ProfileStore] Failed to remove encryption:', error);
+        logger.error('[ProfileStore] Failed to remove encryption:', error);
         set({ error: String(error), pendingUnlock: false });
       }
     }
@@ -318,7 +319,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
     const current = get().current;
     if (!current) return;
 
-    console.log('[ProfileStore] saveProfile called:', {
+    logger.debug('[ProfileStore] saveProfile called:', {
       profileId: current.id,
       profileName: current.name,
       hasPassword: !!password,
@@ -329,7 +330,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
     set({ error: null });
     try {
       await api.profile.save(current, password);
-      console.log('[ProfileStore] saveProfile completed (backend save successful)');
+      logger.debug('[ProfileStore] saveProfile completed (backend save successful)');
       // Update the summary in the list
       const summaries = get().profiles.map((s) =>
         s.name === current.name ? createSummary(current) : s
@@ -340,7 +341,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
       }
       set({ profiles: summaries });
     } catch (error) {
-      console.error('[ProfileStore] saveProfile failed:', error);
+      logger.error('[ProfileStore] saveProfile failed:', error);
       set({ error: String(error) });
     }
   },
@@ -407,14 +408,14 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
     const current = get().current;
     if (current) {
       const updatedProfile = { ...current, ...updates };
-      console.log('[ProfileStore] updateProfile called:', {
+      logger.debug('[ProfileStore] updateProfile called:', {
         profileId: current.id,
         profileName: current.name,
         updateKeys: Object.keys(updates),
       });
       set({ current: updatedProfile });
       await get().saveProfile();
-      console.log('[ProfileStore] updateProfile completed (saveProfile called)');
+      logger.debug('[ProfileStore] updateProfile completed (saveProfile called)');
     }
   },
 
@@ -489,7 +490,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
       // Prevent deletion of the default passthrough group
       const groupToDelete = current.outputGroups.find((g) => g.id === groupId);
       if (groupToDelete?.isDefault) {
-        console.warn('Cannot delete the default passthrough output group');
+        logger.warn('Cannot delete the default passthrough output group');
         return;
       }
 

--- a/apps/web/src/stores/streamStore.ts
+++ b/apps/web/src/stores/streamStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { api } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import { showSystemNotification } from '@/lib/notification';
+import { OBS_TRIGGER_DELAY_MS } from '@/lib/constants';
 import { useSettingsStore } from './settingsStore';
 import { api as httpApi } from '@/lib/backend/httpApi';
 import { useObsStore } from '@/stores/obsStore';
@@ -8,9 +10,6 @@ import i18n from '@/lib/i18n';
 import type { OutputGroup } from '@/types/profile';
 import type { StreamStats, StreamStatusType, TargetStats } from '@/types/stream';
 import type { ObsIntegrationDirection } from '@/types/api';
-
-// OBS integration delay (in ms) before triggering OBS after SpiritStream starts
-const OBS_TRIGGER_DELAY_MS = 2000;
 
 /**
  * Trigger OBS stream start/stop based on integration direction
@@ -32,7 +31,7 @@ async function triggerObsIfEnabled(action: 'start' | 'stop'): Promise<void> {
     // Check if connected to OBS
     const isConnected = await httpApi.obs.isConnected();
     if (!isConnected) {
-      console.log('[StreamStore] OBS not connected, skipping trigger');
+      logger.debug('[StreamStore] OBS not connected, skipping trigger');
       return;
     }
 
@@ -44,15 +43,15 @@ async function triggerObsIfEnabled(action: 'start' | 'stop'): Promise<void> {
 
     // Trigger OBS
     if (action === 'start') {
-      console.log('[StreamStore] Triggering OBS stream start');
+      logger.info('[StreamStore] Triggering OBS stream start');
       await httpApi.obs.startStream();
     } else {
-      console.log('[StreamStore] Triggering OBS stream stop');
+      logger.info('[StreamStore] Triggering OBS stream stop');
       await httpApi.obs.stopStream();
     }
   } catch (error) {
     // Don't fail the main stream action if OBS trigger fails
-    console.error('[StreamStore] Failed to trigger OBS:', error);
+    logger.error('[StreamStore] Failed to trigger OBS:', error);
     // Reset the flag on error
     useObsStore.getState().setTriggeredByUs(false);
   }
@@ -181,7 +180,7 @@ export const useStreamStore = create<StreamState>((set, get) => ({
         globalStatus: isStreaming ? 'live' : 'offline',
       });
     } catch (error) {
-      console.error('[StreamStore] Failed to sync with backend:', error);
+      logger.error('[StreamStore] Failed to sync with backend:', error);
     }
   },
 
@@ -190,7 +189,7 @@ export const useStreamStore = create<StreamState>((set, get) => ({
     try {
       return await api.stream.isGroupStreaming(groupId);
     } catch (error) {
-      console.error('[StreamStore] Failed to check group streaming status:', error);
+      logger.error('[StreamStore] Failed to check group streaming status:', error);
       return false;
     }
   },
@@ -502,13 +501,13 @@ export const useStreamStore = create<StreamState>((set, get) => ({
       // Fire and forget - don't block stream start on webhook
       api.discord.sendNotification().then((result) => {
         if (result.success && !result.skippedCooldown) {
-          console.log('[StreamStore] Discord go-live notification sent');
+          logger.info('[StreamStore] Discord go-live notification sent');
         } else if (result.skippedCooldown) {
-          console.log('[StreamStore] Discord notification skipped (cooldown active)');
+          logger.debug('[StreamStore] Discord notification skipped (cooldown active)');
         }
       }).catch((error) => {
         // Don't fail stream start if webhook fails
-        console.warn('[StreamStore] Discord notification failed:', error);
+        logger.warn('[StreamStore] Discord notification failed:', error);
       });
     }
   },

--- a/apps/web/src/stores/themeStore.ts
+++ b/apps/web/src/stores/themeStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { api, events } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import type { ThemeSummary, ThemeMode } from '@/types/theme';
 
 interface ThemeState {
@@ -76,31 +77,37 @@ function clearThemeOverrides() {
   }
 }
 
+function isLegacyThemeState(value: unknown): value is { state?: { currentThemeId?: string; themeId?: string } } {
+  return typeof value === 'object' && value !== null && 'state' in value;
+}
+
+function hasThemeId(value: unknown): value is { themeId: string } {
+  return typeof value === 'object' && value !== null && 'themeId' in value && typeof (value as Record<string, unknown>).themeId === 'string';
+}
+
 function migrateOldThemeFormat(): { themeId: string } | null {
   try {
     const oldData = localStorage.getItem('spiritstream-theme');
     if (!oldData) return null;
 
-    const parsed = JSON.parse(oldData);
-    if (parsed && typeof parsed === 'object' && 'state' in parsed) {
-      const state = (parsed as { state?: { currentThemeId?: string } }).state;
+    const parsed: unknown = JSON.parse(oldData);
+    if (isLegacyThemeState(parsed)) {
+      const state = parsed.state;
       if (state?.currentThemeId) {
         return null; // Already persisted in the current format
       }
     }
 
-    const legacy = (parsed && typeof parsed === 'object' && 'state' in parsed
-      ? (parsed as { state?: Record<string, unknown> }).state
-      : parsed) as { theme?: string; themeId?: string } | null;
+    const legacy = isLegacyThemeState(parsed) ? parsed.state : parsed;
 
-    if (!legacy || !legacy.themeId) {
+    if (!hasThemeId(legacy)) {
       return null;
     }
 
     const themeId = legacy.themeId;
     return { themeId };
   } catch (error) {
-    console.error('Failed to migrate old theme format:', error);
+    logger.error('Failed to migrate old theme format:', error);
     return null;
   }
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -19,53 +19,90 @@
   /* Sidebar dimensions - generates w-sidebar, ml-sidebar, etc. */
   --spacing-sidebar: 260px;
 
-  /* Custom colors mapped to CSS variables */
+  /* Primary brand */
   --color-primary: var(--primary);
   --color-primary-hover: var(--primary-hover);
+  --color-primary-active: var(--primary-active);
   --color-primary-subtle: var(--primary-subtle);
   --color-primary-muted: var(--primary-muted);
+  --color-primary-foreground: var(--primary-foreground);
 
+  /* Secondary brand */
   --color-secondary: var(--secondary);
   --color-secondary-hover: var(--secondary-hover);
+  --color-secondary-active: var(--secondary-active);
   --color-secondary-subtle: var(--secondary-subtle);
+  --color-secondary-foreground: var(--secondary-foreground);
 
+  /* Accent brand */
   --color-accent: var(--accent);
   --color-accent-hover: var(--accent-hover);
+  --color-accent-active: var(--accent-active);
   --color-accent-subtle: var(--accent-subtle);
+  --color-accent-foreground: var(--accent-foreground);
 
+  /* Success */
   --color-success: var(--success);
   --color-success-subtle: var(--success-subtle);
   --color-success-text: var(--success-text);
+  --color-success-border: var(--success-border);
 
+  /* Warning */
   --color-warning: var(--warning);
   --color-warning-subtle: var(--warning-subtle);
   --color-warning-text: var(--warning-text);
+  --color-warning-border: var(--warning-border);
 
+  /* Error */
   --color-error: var(--error);
+  --color-error-hover: var(--error-hover);
   --color-error-subtle: var(--error-subtle);
   --color-error-text: var(--error-text);
+  --color-error-foreground: var(--error-foreground);
+  --color-error-border: var(--error-border);
 
-  /* Background colors */
+  /* Backgrounds */
   --color-bg-base: var(--bg-base);
   --color-bg-surface: var(--bg-surface);
   --color-bg-elevated: var(--bg-elevated);
   --color-bg-muted: var(--bg-muted);
   --color-bg-sunken: var(--bg-sunken);
   --color-bg-hover: var(--bg-hover);
+  --color-bg-overlay: var(--bg-overlay);
 
-  /* Text colors */
+  /* Text */
   --color-text-primary: var(--text-primary);
   --color-text-secondary: var(--text-secondary);
   --color-text-tertiary: var(--text-tertiary);
   --color-text-muted: var(--text-muted);
 
-  /* Border colors */
+  /* Borders */
   --color-border-default: var(--border-default);
   --color-border-muted: var(--border-muted);
+  --color-border-subtle: var(--border-subtle);
   --color-border-strong: var(--border-strong);
+  --color-border-stronger: var(--border-stronger);
   --color-border-interactive: var(--border-interactive);
 
-  /* Shadow configuration */
+  /* Focus ring */
+  --color-ring-default: var(--ring-default);
+  --color-ring-offset: var(--ring-offset);
+
+  /* Streaming status */
+  --color-status-live: var(--status-live);
+  --color-status-live-bg: var(--status-live-bg);
+  --color-status-live-text: var(--status-live-text);
+  --color-status-connecting: var(--status-connecting);
+  --color-status-connecting-bg: var(--status-connecting-bg);
+  --color-status-connecting-text: var(--status-connecting-text);
+  --color-status-offline: var(--status-offline);
+  --color-status-offline-bg: var(--status-offline-bg);
+  --color-status-offline-text: var(--status-offline-text);
+  --color-status-error: var(--status-error);
+  --color-status-error-bg: var(--status-error-bg);
+  --color-status-error-text: var(--status-error-text);
+
+  /* Shadows */
   --shadow-xs: var(--shadow-xs);
   --shadow-sm: var(--shadow-sm);
   --shadow-md: var(--shadow-md);
@@ -73,96 +110,100 @@
   --shadow-xl: var(--shadow-xl);
 }
 
-/* Reset */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+/* Reset - must be in @layer base so Tailwind utilities can override */
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
 }
 
-/* Base */
-html {
-  font-size: 16px;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@layer base {
+  /* Base */
+  html {
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 
-body {
-  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: var(--bg-base);
-  color: var(--text-primary);
-  line-height: 1.5;
-  min-height: 100vh;
-}
+  body {
+    font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg-base);
+    color: var(--text-primary);
+    line-height: 1.5;
+    min-height: 100vh;
+  }
 
-/* Chat overlay window styles */
-html[data-window='chat-overlay'],
-body[data-window='chat-overlay'] {
-  background: var(--bg-base);
-}
+  /* Chat overlay window styles */
+  html[data-window='chat-overlay'],
+  body[data-window='chat-overlay'] {
+    background: var(--bg-base);
+  }
 
-html[data-window='chat-overlay'][data-overlay-transparent='true'],
-body[data-window='chat-overlay'][data-overlay-transparent='true'] {
-  background: transparent !important;
-}
+  html[data-window='chat-overlay'][data-overlay-transparent='true'],
+  body[data-window='chat-overlay'][data-overlay-transparent='true'] {
+    background: transparent !important;
+  }
 
-body[data-window='chat-overlay'] #root {
-  min-height: 100vh;
-  background: transparent;
-}
+  body[data-window='chat-overlay'] #root {
+    min-height: 100vh;
+    background: transparent;
+  }
 
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
+  /* Scrollbar */
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
 
-::-webkit-scrollbar-track {
-  background: var(--scrollbar-track);
-}
+  ::-webkit-scrollbar-track {
+    background: var(--scrollbar-track);
+  }
 
-::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb);
-  border-radius: 4px;
-}
+  ::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: 4px;
+  }
 
-::-webkit-scrollbar-thumb:hover {
-  background: var(--scrollbar-thumb-hover);
-}
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
+  }
 
-/* Focus styles */
-:focus-visible {
-  outline: var(--ring-width) solid var(--ring-default);
-  outline-offset: var(--ring-offset-width);
-}
+  /* Focus styles */
+  :focus-visible {
+    outline: var(--ring-width) solid var(--ring-default);
+    outline-offset: var(--ring-offset-width);
+  }
 
-:focus:not(:focus-visible) {
-  outline: none;
-}
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
 
-/* Links */
-a {
-  color: var(--primary);
-  text-decoration: none;
-}
+  /* Links */
+  a {
+    color: var(--primary);
+    text-decoration: none;
+  }
 
-a:hover {
-  color: var(--primary-hover);
-  text-decoration: underline;
-}
+  a:hover {
+    color: var(--primary-hover);
+    text-decoration: underline;
+  }
 
-/* Code */
-code,
-pre {
-  font-family: 'JetBrains Mono', monospace;
-}
+  /* Code */
+  code,
+  pre {
+    font-family: 'JetBrains Mono', monospace;
+  }
 
-/* Selection */
-::selection {
-  background: var(--primary-subtle);
-  color: var(--primary);
+  /* Selection */
+  ::selection {
+    background: var(--primary-subtle);
+    color: var(--primary);
+  }
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/apps/web/src/views/Chat.tsx
+++ b/apps/web/src/views/Chat.tsx
@@ -10,12 +10,14 @@ import { Modal } from '@/components/ui/Modal';
 import { ChatList } from '@/components/chat/ChatList';
 import { CHAT_OVERLAY_SETTINGS_EVENT, CHAT_OVERLAY_ALWAYS_ON_TOP_EVENT } from '@/lib/chatEvents';
 import { openChatOverlay, setOverlayAlwaysOnTop } from '@/lib/chatWindow';
+import { CHAT_POLL_INTERVAL_MS } from '@/lib/constants';
 import { useChatStore } from '@/stores/chatStore';
 import { useProfileStore } from '@/stores/profileStore';
 import { api, dialogs } from '@/lib/backend';
 import type { ChatMessage, ChatPlatformStatus } from '@/types/chat';
 import { createDefaultChatSettings } from '@/types/profile';
 import { toast } from '@/hooks/useToast';
+import { logger } from '@/lib/logger';
 import { cn } from '@/lib/cn';
 
 export function Chat() {
@@ -44,7 +46,7 @@ export function Chat() {
   const handleTransparentToggle = (transparent: boolean) => {
     setOverlayTransparent(transparent);
     emit(CHAT_OVERLAY_SETTINGS_EVENT, { transparent }).catch((error) => {
-      console.error('Failed to sync chat overlay settings:', error);
+      logger.error('Failed to sync chat overlay settings:', error);
     });
   };
 
@@ -52,7 +54,7 @@ export function Chat() {
     setOverlayAlwaysOnTopState(alwaysOnTop);
     setOverlayAlwaysOnTop(alwaysOnTop);
     emit(CHAT_OVERLAY_ALWAYS_ON_TOP_EVENT, { alwaysOnTop }).catch((error) => {
-      console.error('Failed to sync chat overlay always on top:', error);
+      logger.error('Failed to sync chat overlay always on top:', error);
     });
   };
 
@@ -66,7 +68,7 @@ export function Chat() {
         setStatuses(loadedStatuses);
         setActiveStreamCount(streamCount);
       } catch (error) {
-        console.error('Failed to load chat settings:', error);
+        logger.error('Failed to load chat settings:', error);
       }
     };
     load();
@@ -82,9 +84,9 @@ export function Chat() {
         setStatuses(loadedStatuses);
         setActiveStreamCount(streamCount);
       } catch (error) {
-        console.error('Failed to refresh chat status:', error);
+        logger.error('Failed to refresh chat status:', error);
       }
-    }, 5000);
+    }, CHAT_POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
   }, []);
@@ -197,7 +199,7 @@ export function Chat() {
         t('chat.exportSuccess', { defaultValue: 'Chat log exported.' })
       );
     } catch (error) {
-      console.error('Failed to export chat log:', error);
+      logger.error('Failed to export chat log:', error);
       toast.error(
         t('chat.exportFailed', { defaultValue: 'Failed to export chat log.' })
       );
@@ -216,7 +218,7 @@ export function Chat() {
       const results = await api.chat.searchSession(query, 500);
       setSearchResults(results);
     } catch (error) {
-      console.error('Failed to search chat session:', error);
+      logger.error('Failed to search chat session:', error);
       toast.error(
         t('chat.searchFailed', { defaultValue: 'Failed to search chat logs.' })
       );
@@ -257,13 +259,13 @@ export function Chat() {
   const statusDotClass = (status: ChatPlatformStatus['status']) => {
     switch (status) {
       case 'connected':
-        return 'bg-[var(--status-live)]';
+        return 'bg-status-live';
       case 'connecting':
-        return 'bg-[var(--status-connecting)]';
+        return 'bg-status-connecting';
       case 'error':
-        return 'bg-[var(--status-error)]';
+        return 'bg-status-error';
       default:
-        return 'bg-[var(--text-tertiary)]';
+        return 'bg-text-tertiary';
     }
   };
 
@@ -341,7 +343,7 @@ export function Chat() {
       setDraftMessage('');
     } catch (error) {
       toast.error(t('chat.sendFailed', { defaultValue: 'Failed to send message' }));
-      console.error('Failed to send chat message:', error);
+      logger.error('Failed to send chat message:', error);
     } finally {
       setIsSending(false);
     }
@@ -360,8 +362,8 @@ export function Chat() {
         </div>
       </CardHeader>
       <CardBody>
-        <div className="flex flex-wrap items-center justify-between" style={{ gap: '16px' }}>
-          <div className="flex flex-wrap items-center" style={{ gap: '24px' }}>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-wrap items-center gap-6">
             <Toggle
               checked={overlayTransparent}
               onChange={handleTransparentToggle}
@@ -379,7 +381,7 @@ export function Chat() {
               })}
             />
           </div>
-          <div className="flex items-center" style={{ gap: '12px' }}>
+          <div className="flex items-center gap-3">
             <Button variant="ghost" size="sm" onClick={clearMessages}>
               <Trash2 className="w-4 h-4" />
               {t('common.clear')}
@@ -403,7 +405,7 @@ export function Chat() {
             </Button>
           </div>
         </div>
-        <div className="mt-6 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-4">
+        <div className="mt-6 rounded-xl border border-border-subtle bg-bg-elevated p-4">
           <ChatList
             messages={messages}
             className="max-h-[520px]"
@@ -438,11 +440,11 @@ export function Chat() {
             </Button>
           </div>
           {sendTargets.length === 0 ? (
-            <p className="text-xs text-[var(--text-tertiary)]">
+            <p className="text-xs text-text-tertiary">
               {sendDisabledReason}
             </p>
           ) : (
-            <p className="text-xs text-[var(--text-tertiary)]">
+            <p className="text-xs text-text-tertiary">
               {t('chat.sendTargets', {
                 defaultValue: 'Sending to: {{targets}}',
                 targets: sendTargetLabel,
@@ -450,19 +452,19 @@ export function Chat() {
             </p>
           )}
           {platformStates.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-tertiary)]">
-              <span className="font-medium text-[var(--text-secondary)]">
+            <div className="flex flex-wrap items-center gap-2 text-xs text-text-tertiary">
+              <span className="font-medium text-text-secondary">
                 {t('chat.sendStatus', { defaultValue: 'Send status:' })}
               </span>
               {platformStates.map((platform) => (
                 <div
                   key={platform.id}
-                  className="flex items-center gap-2 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-elevated)] px-2 py-1"
+                  className="flex items-center gap-2 rounded-full border border-border-subtle bg-bg-elevated px-2 py-1"
                 >
                   <span
                     className={cn('inline-block h-2 w-2 rounded-full', statusDotClass(platform.status))}
                   />
-                  <span className="text-[var(--text-primary)]">{platform.label}</span>
+                  <span className="text-text-primary">{platform.label}</span>
                   <span>
                     {platform.configured
                       ? t('chat.platformConfigured', { defaultValue: 'Configured' })
@@ -537,7 +539,7 @@ export function Chat() {
             emptyLabel={searchEmptyLabel}
             showTimestamps
           />
-          <div className="flex items-center justify-between text-xs text-[var(--text-tertiary)]">
+          <div className="flex items-center justify-between text-xs text-text-tertiary">
             <span>
               {searchScope === 'session'
                 ? t('chat.searchSessionHint', {

--- a/apps/web/src/views/ChatOverlay.tsx
+++ b/apps/web/src/views/ChatOverlay.tsx
@@ -13,6 +13,7 @@ import {
   CHAT_OVERLAY_SYNC_REQUEST_EVENT,
 } from '@/lib/chatEvents';
 import { isTauri } from '@/lib/backend/env';
+import { logger } from '@/lib/logger';
 import { setupOverlayAutoClose } from '@/lib/chatWindow';
 import { useChatStore } from '@/stores/chatStore';
 import type { ChatMessage } from '@/types/chat';
@@ -47,7 +48,7 @@ export function ChatOverlay() {
         const currentWindow = getCurrentWindow();
         await currentWindow.setAlwaysOnTop(event.payload.alwaysOnTop);
       } catch (error) {
-        console.error('Failed to set always on top:', error);
+        logger.error('Failed to set always on top:', error);
       }
     }).then((fn) => {
       unlistenAlwaysOnTop = fn;
@@ -71,7 +72,7 @@ export function ChatOverlay() {
   useEffect(() => {
     if (isTauri()) {
       emit(CHAT_OVERLAY_SYNC_REQUEST_EVENT, {}).catch((error) => {
-        console.error('Failed to request chat overlay sync:', error);
+        logger.error('Failed to request chat overlay sync:', error);
       });
       return;
     }
@@ -87,7 +88,7 @@ export function ChatOverlay() {
     };
 
     window.addEventListener('message', handleMessage);
-    window.opener.postMessage({ type: 'chat-overlay-sync-request' }, '*');
+    window.opener.postMessage({ type: 'chat-overlay-sync-request' }, window.location.origin);
 
     return () => {
       window.removeEventListener('message', handleMessage);
@@ -124,13 +125,13 @@ export function ChatOverlay() {
     try {
       await WebviewWindow.getCurrent().close();
     } catch (error) {
-      console.error('Failed to close chat overlay window:', error);
+      logger.error('Failed to close chat overlay window:', error);
     }
   };
 
   const handleDragStart = () => {
     getCurrentWindow().startDragging().catch((error) => {
-      console.error('Failed to start dragging chat overlay window:', error);
+      logger.error('Failed to start dragging chat overlay window:', error);
     });
   };
 
@@ -138,7 +139,7 @@ export function ChatOverlay() {
     <div
       className={cn(
         'min-h-screen w-full flex flex-col',
-        overlayTransparent ? 'bg-transparent' : 'bg-[var(--bg-base)]'
+        overlayTransparent ? 'bg-transparent' : 'bg-bg-base'
       )}
     >
       <div

--- a/apps/web/src/views/Dashboard.tsx
+++ b/apps/web/src/views/Dashboard.tsx
@@ -275,7 +275,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--text-secondary)]">{t('common.loading')}</div>
+        <div className="text-text-secondary">{t('common.loading')}</div>
       </div>
     );
   }
@@ -283,7 +283,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--error-text)]">
+        <div className="text-error-text">
           {t('common.error')}: {error}
         </div>
       </div>
@@ -321,7 +321,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
         />
       </StatsRow>
 
-      <Grid cols={2} style={{ marginBottom: '24px' }}>
+      <Grid cols={2} className="mb-6">
         <Card>
           <CardHeader>
             <div>
@@ -356,7 +356,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
                 active
               />
             ) : (
-              <div className="text-center py-8 text-[var(--text-secondary)]">
+              <div className="text-center py-8 text-text-secondary">
                 <p>{t('dashboard.noProfileSelected')}</p>
                 <Button variant="primary" className="mt-4" onClick={onOpenProfileModal}>
                   {t('dashboard.createProfile')}
@@ -449,7 +449,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
               ))}
             </Grid>
           ) : (
-            <div className="text-center py-8 text-[var(--text-secondary)]">
+            <div className="text-center py-8 text-text-secondary">
               <p>{t('dashboard.noStreamTargets')}</p>
               <Button
                 variant="outline"
@@ -465,7 +465,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
       </Card>
 
       {/* Output Groups Section */}
-      <Card style={{ marginTop: '24px' }}>
+      <Card className="mt-6">
         <CardHeader>
           <div>
             <CardTitle>{t('dashboard.outputGroups')}</CardTitle>
@@ -494,7 +494,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
               ))}
             </Grid>
           ) : (
-            <div className="text-center py-8 text-[var(--text-secondary)]">
+            <div className="text-center py-8 text-text-secondary">
               <p>{t('dashboard.noOutputGroups')}</p>
               <Button
                 variant="outline"
@@ -510,7 +510,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
       </Card>
 
       {/* Encoder Settings Section */}
-      <Card style={{ marginTop: '24px' }}>
+      <Card className="mt-6">
         <CardHeader>
           <div>
             <CardTitle>{t('dashboard.encoderSettings')}</CardTitle>
@@ -535,7 +535,7 @@ export function Dashboard({ onNavigate, onOpenProfileModal, onOpenTargetModal }:
               ))}
             </Grid>
           ) : (
-            <div className="text-center py-8 text-[var(--text-secondary)]">
+            <div className="text-center py-8 text-text-secondary">
               <p>{t('dashboard.noEncoderSettings')}</p>
               <Button
                 variant="outline"

--- a/apps/web/src/views/EncoderSettings.tsx
+++ b/apps/web/src/views/EncoderSettings.tsx
@@ -24,7 +24,7 @@ export function EncoderSettings() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--text-secondary)]">{t('common.loading')}</div>
+        <div className="text-text-secondary">{t('common.loading')}</div>
       </div>
     );
   }
@@ -33,7 +33,7 @@ export function EncoderSettings() {
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--error-text)]">
+        <div className="text-error-text">
           {t('common.error')}: {error}
         </div>
       </div>
@@ -46,7 +46,7 @@ export function EncoderSettings() {
       <Card>
         <CardBody>
           <div className="text-center py-12">
-            <p className="text-[var(--text-secondary)]">
+            <p className="text-text-secondary">
               {tDynamic('encoder.selectProfileFirst', { defaultValue: 'Select a profile first' })}
             </p>
           </div>
@@ -97,22 +97,19 @@ export function EncoderSettings() {
       <>
         <Card>
           <CardBody>
-            <div className="text-center" style={{ padding: '48px 0' }}>
+            <div className="text-center py-12">
               <div
-                className="w-16 h-16 mx-auto rounded-full bg-[var(--primary-subtle)] flex items-center justify-center"
-                style={{ marginBottom: '16px' }}
+                className="w-16 h-16 mx-auto rounded-full bg-primary-subtle flex items-center justify-center mb-4"
               >
-                <Cpu className="w-8 h-8 text-[var(--primary)]" />
+                <Cpu className="w-8 h-8 text-primary" />
               </div>
               <h3
-                className="text-lg font-semibold text-[var(--text-primary)]"
-                style={{ marginBottom: '8px' }}
+                className="text-lg font-semibold text-text-primary mb-2"
               >
                 {tDynamic('encoder.noEncoders', { defaultValue: 'No Encoder Configurations' })}
               </h3>
               <p
-                className="text-[var(--text-secondary)] max-w-md mx-auto"
-                style={{ marginBottom: '24px' }}
+                className="text-text-secondary max-w-md mx-auto mb-6"
               >
                 {tDynamic('encoder.noEncodersDescription', {
                   defaultValue:
@@ -138,7 +135,7 @@ export function EncoderSettings() {
   }
 
   return (
-    <div className="flex flex-col" style={{ gap: '16px' }}>
+    <div className="flex flex-col gap-4">
       {/* Encoder Cards */}
       {outputGroups.map((group) => (
         <EncoderCard
@@ -153,12 +150,12 @@ export function EncoderSettings() {
 
       {/* Add New Encoder Card */}
       <Card
-        className="border-2 border-dashed border-[var(--border-default)] hover:border-[var(--primary)] transition-colors cursor-pointer"
+        className="border-2 border-dashed border-border-default hover:border-primary transition-colors cursor-pointer"
         onClick={() => setCreateModalOpen(true)}
       >
-        <CardBody className="flex items-center justify-center" style={{ padding: '32px 24px' }}>
+        <CardBody className="flex items-center justify-center py-8 px-6">
           <Button variant="ghost">
-            <Plus className="w-5 h-5" style={{ marginRight: '8px' }} />
+            <Plus className="w-5 h-5 mr-2" />
             {tDynamic('encoder.addEncoder', { defaultValue: 'Add Encoder' })}
           </Button>
         </CardBody>

--- a/apps/web/src/views/Integrations.tsx
+++ b/apps/web/src/views/Integrations.tsx
@@ -14,14 +14,14 @@ export function Integrations() {
 
   return (
     <div className="space-y-6">
-      <div className="flex gap-2 border-b border-[var(--border-default)] pb-2">
+      <div className="flex gap-2 border-b border-border-default pb-2">
         <button
           onClick={() => setActiveTab('chat')}
           className={cn(
             'flex items-center gap-2 px-4 py-2 rounded-t-lg text-sm font-medium transition-colors',
             activeTab === 'chat'
-              ? 'bg-[var(--bg-surface)] text-[var(--text-primary)] border border-b-0 border-[var(--border-default)]'
-              : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)]'
+              ? 'bg-bg-surface text-text-primary border border-b-0 border-border-default'
+              : 'text-text-secondary hover:text-text-primary hover:bg-bg-muted'
           )}
         >
           <MessageSquare className="w-4 h-4" />
@@ -32,8 +32,8 @@ export function Integrations() {
           className={cn(
             'flex items-center gap-2 px-4 py-2 rounded-t-lg text-sm font-medium transition-colors',
             activeTab === 'obs'
-              ? 'bg-[var(--bg-surface)] text-[var(--text-primary)] border border-b-0 border-[var(--border-default)]'
-              : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)]'
+              ? 'bg-bg-surface text-text-primary border border-b-0 border-border-default'
+              : 'text-text-secondary hover:text-text-primary hover:bg-bg-muted'
           )}
         >
           <Radio className="w-4 h-4" />
@@ -44,8 +44,8 @@ export function Integrations() {
           className={cn(
             'flex items-center gap-2 px-4 py-2 rounded-t-lg text-sm font-medium transition-colors',
             activeTab === 'discord'
-              ? 'bg-[var(--bg-surface)] text-[var(--text-primary)] border border-b-0 border-[var(--border-default)]'
-              : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)]'
+              ? 'bg-bg-surface text-text-primary border border-b-0 border-border-default'
+              : 'text-text-secondary hover:text-text-primary hover:bg-bg-muted'
           )}
         >
           <Send className="w-4 h-4" />

--- a/apps/web/src/views/Logs.tsx
+++ b/apps/web/src/views/Logs.tsx
@@ -9,6 +9,7 @@ import { LogEntry } from '@/components/feedback/LogEntry';
 import type { LogLevel } from '@/types/stream';
 import { useLogStore } from '@/stores/logStore';
 import { dialogs } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import { toast } from '@/hooks/useToast';
 
 export function Logs() {
@@ -90,7 +91,7 @@ export function Logs() {
         // User cancelled - don't show error
         return;
       }
-      console.error('Failed to export logs:', error);
+      logger.error('Failed to export logs:', error);
       toast.error(t('logs.exportFailed', { defaultValue: 'Failed to export logs' }));
     }
   };
@@ -121,7 +122,7 @@ export function Logs() {
           <CardTitle>{t('logs.title')}</CardTitle>
           <CardDescription>{t('logs.description')}</CardDescription>
         </div>
-        <div className="flex items-center" style={{ gap: '12px' }}>
+        <div className="flex items-center gap-3">
           <Select
             value={timeFilter}
             onChange={(e) =>
@@ -155,13 +156,12 @@ export function Logs() {
           </Button>
         </div>
       </CardHeader>
-      <CardBody style={{ padding: 0 }}>
+      <CardBody className="p-0">
         <LogConsole maxHeight="500px">
           <div ref={consoleRef}>
             {filteredLogs.length === 0 ? (
               <div
-                className="text-center text-[var(--text-secondary)]"
-                style={{ padding: '32px 16px' }}
+                className="text-center text-text-secondary py-8 px-4"
               >
                 {t('logs.noLogs')}
               </div>

--- a/apps/web/src/views/OutputGroups.tsx
+++ b/apps/web/src/views/OutputGroups.tsx
@@ -8,6 +8,7 @@ import { OutputGroupModal, TargetModal } from '@/components/modals';
 import { useProfileStore } from '@/stores/profileStore';
 import { useStreamStore } from '@/stores/streamStore';
 import { api } from '@/lib/backend';
+import { logger } from '@/lib/logger';
 import type { OutputGroup } from '@/types/profile';
 import type { Encoders } from '@/types/stream';
 
@@ -28,7 +29,7 @@ export function OutputGroups() {
     api.system
       .getEncoders()
       .then(setEncoders)
-      .catch((err) => console.error('Failed to load encoders:', err));
+      .catch((err) => logger.error('Failed to load encoders:', err));
   }, []);
 
   const openEditModal = (group: OutputGroup) => {
@@ -54,7 +55,7 @@ export function OutputGroups() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--text-secondary)]">{t('common.loading')}</div>
+        <div className="text-text-secondary">{t('common.loading')}</div>
       </div>
     );
   }
@@ -62,7 +63,7 @@ export function OutputGroups() {
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--error-text)]">
+        <div className="text-error-text">
           {t('common.error')}: {error}
         </div>
       </div>
@@ -74,7 +75,7 @@ export function OutputGroups() {
       <Card>
         <CardBody>
           <div className="text-center py-12">
-            <p className="text-[var(--text-secondary)]">{t('outputs.selectProfileFirst')}</p>
+            <p className="text-text-secondary">{t('outputs.selectProfileFirst')}</p>
           </div>
         </CardBody>
       </Card>
@@ -88,22 +89,19 @@ export function OutputGroups() {
       <>
         <Card>
           <CardBody>
-            <div className="text-center" style={{ padding: '48px 0' }}>
+            <div className="text-center py-12">
               <div
-                className="w-16 h-16 mx-auto rounded-full bg-[var(--primary-subtle)] flex items-center justify-center"
-                style={{ marginBottom: '16px' }}
+                className="w-16 h-16 mx-auto rounded-full bg-primary-subtle flex items-center justify-center mb-4"
               >
-                <Plus className="w-8 h-8 text-[var(--primary)]" />
+                <Plus className="w-8 h-8 text-primary" />
               </div>
               <h3
-                className="text-lg font-semibold text-[var(--text-primary)]"
-                style={{ marginBottom: '8px' }}
+                className="text-lg font-semibold text-text-primary mb-2"
               >
                 {t('outputs.noOutputGroups')}
               </h3>
               <p
-                className="text-[var(--text-secondary)] max-w-md mx-auto"
-                style={{ marginBottom: '24px' }}
+                className="text-text-secondary max-w-md mx-auto mb-6"
               >
                 {t('outputs.noOutputGroupsDescription')}
               </p>
@@ -145,7 +143,7 @@ export function OutputGroups() {
   };
 
   return (
-    <div className="flex flex-col" style={{ gap: '16px' }}>
+    <div className="flex flex-col gap-4">
       {outputGroups.map((group, index) => (
         <OutputGroupCard
           key={group.id}
@@ -163,12 +161,12 @@ export function OutputGroups() {
 
       {/* Add New Group Button */}
       <Card
-        className="border-2 border-dashed border-[var(--border-default)] hover:border-[var(--primary)] transition-colors cursor-pointer"
+        className="border-2 border-dashed border-border-default hover:border-primary transition-colors cursor-pointer"
         onClick={() => setCreateModalOpen(true)}
       >
-        <CardBody className="flex items-center justify-center" style={{ padding: '32px 24px' }}>
+        <CardBody className="flex items-center justify-center py-8 px-6">
           <Button variant="ghost">
-            <Plus className="w-5 h-5" style={{ marginRight: '8px' }} />
+            <Plus className="w-5 h-5 mr-2" />
             {t('outputs.addOutputGroup')}
           </Button>
         </CardBody>

--- a/apps/web/src/views/Profiles.tsx
+++ b/apps/web/src/views/Profiles.tsx
@@ -166,7 +166,7 @@ export function Profiles() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--text-secondary)]">{t('profiles.loadingProfiles')}</div>
+        <div className="text-text-secondary">{t('profiles.loadingProfiles')}</div>
       </div>
     );
   }
@@ -174,7 +174,7 @@ export function Profiles() {
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--error-text)]">
+        <div className="text-error-text">
           {t('common.error')}: {error}
         </div>
       </div>
@@ -187,22 +187,19 @@ export function Profiles() {
       <>
         <Card>
           <CardBody>
-            <div className="text-center" style={{ padding: '48px 0' }}>
+            <div className="text-center py-12">
               <div
-                className="w-16 h-16 mx-auto rounded-full bg-[var(--primary-subtle)] flex items-center justify-center"
-                style={{ marginBottom: '16px' }}
+                className="w-16 h-16 mx-auto rounded-full bg-primary-subtle flex items-center justify-center mb-4"
               >
-                <Plus className="w-8 h-8 text-[var(--primary)]" />
+                <Plus className="w-8 h-8 text-primary" />
               </div>
               <h3
-                className="text-lg font-semibold text-[var(--text-primary)]"
-                style={{ marginBottom: '8px' }}
+                className="text-lg font-semibold text-text-primary mb-2"
               >
                 {t('profiles.noProfilesYet')}
               </h3>
               <p
-                className="text-[var(--text-secondary)] max-w-md mx-auto"
-                style={{ marginBottom: '24px' }}
+                className="text-text-secondary max-w-md mx-auto mb-6"
               >
                 {t('profiles.noProfilesDescription')}
               </p>
@@ -264,7 +261,7 @@ export function Profiles() {
                   active={current?.id === profile.id}
                   onClick={() => handleProfileClick(profile.name)}
                   actions={
-                    <div className="flex" style={{ gap: '4px' }}>
+                    <div className="flex gap-1">
                       <Button
                         variant="ghost"
                         size="sm"
@@ -293,7 +290,7 @@ export function Profiles() {
                           handleDeleteClick(profile.name);
                         }}
                         title={t('common.delete')}
-                        className="text-[var(--error-text)] hover:bg-[var(--error-subtle)]"
+                        className="text-error-text hover:bg-error-subtle"
                       >
                         <Trash2 className="w-4 h-4" />
                       </Button>
@@ -336,7 +333,7 @@ export function Profiles() {
                             <Unlock
                               className={cn(
                                 "w-4 h-4 transition-all duration-300",
-                                isUnlocked && "text-[var(--success)] scale-110"
+                                isUnlocked && "text-success scale-110"
                               )}
                             />
                           </Button>
@@ -350,20 +347,18 @@ export function Profiles() {
 
             {/* Add New Profile Card */}
             <Card
-              className="border-2 border-dashed border-[var(--border-default)] hover:border-[var(--primary)] transition-colors cursor-pointer h-full"
+              className="border-2 border-dashed border-border-default hover:border-primary transition-colors cursor-pointer h-full"
               onClick={() => setCreateModalOpen(true)}
             >
               <CardBody
-                className="flex flex-col items-center justify-center h-full"
-                style={{ padding: '20px' }}
+                className="flex flex-col items-center justify-center h-full p-5"
               >
                 <div
-                  className="w-14 h-14 rounded-full bg-[var(--primary-subtle)] flex items-center justify-center"
-                  style={{ marginBottom: '16px' }}
+                  className="w-14 h-14 rounded-full bg-primary-subtle flex items-center justify-center mb-4"
                 >
-                  <Plus className="w-7 h-7 text-[var(--primary)]" />
+                  <Plus className="w-7 h-7 text-primary" />
                 </div>
-                <span className="text-base font-medium text-[var(--text-secondary)]">
+                <span className="text-base font-medium text-text-secondary">
                   {t('profiles.createNewProfile')}
                 </span>
               </CardBody>
@@ -417,7 +412,7 @@ export function Profiles() {
           </>
         }
       >
-        <p className="text-[var(--text-secondary)]">
+        <p className="text-text-secondary">
           {t('profiles.deleteConfirmation', { name: deletingProfileName })}
         </p>
       </Modal>

--- a/apps/web/src/views/Settings.tsx
+++ b/apps/web/src/views/Settings.tsx
@@ -28,6 +28,7 @@ import { useProfileStore } from '@/stores/profileStore';
 import { useQueryClient } from '@tanstack/react-query';
 import type { AppSettings } from '@/types/api';
 import type { ProfileSettings as ProfileSettingsType, BackendSettings } from '@/types/profile';
+import { logger } from '@/lib/logger';
 import { cn } from '@/lib/cn';
 
 type SettingsTab = 'global' | 'profile';
@@ -124,7 +125,7 @@ export function Settings() {
         }
       }
     } catch (error) {
-      console.error('Failed to open file dialog:', error);
+      logger.error('Failed to open file dialog:', error);
     }
   };
 
@@ -139,7 +140,7 @@ export function Settings() {
         await dialogs.openExternal(settings?.profileStoragePath || '');
       }
     } catch (error) {
-      console.error('Failed to open profile storage:', error);
+      logger.error('Failed to open profile storage:', error);
     }
   };
 
@@ -159,7 +160,7 @@ export function Settings() {
       await api.settings.exportData(selected);
       alert(t('toast.dataExported'));
     } catch (error) {
-      console.error('Failed to export data:', error);
+      logger.error('Failed to export data:', error);
       alert(`${t('settings.exportFailed')}: ${error}`);
     }
   };
@@ -186,7 +187,7 @@ export function Settings() {
       await api.theme.install(selected);
       await refreshThemes();
     } catch (error) {
-      console.error('Failed to install theme:', error);
+      logger.error('Failed to install theme:', error);
       setThemeInstallError(String(error));
     } finally {
       setThemeInstalling(false);
@@ -213,7 +214,7 @@ export function Settings() {
       queryClient.invalidateQueries({ queryKey: SETTINGS_QUERY_KEY });
       setClearConfirmOpen(false);
     } catch (error) {
-      console.error('Failed to clear data:', error);
+      logger.error('Failed to clear data:', error);
       setClearError(`${t('settings.clearFailed')}: ${error}`);
     } finally {
       setClearInProgress(false);
@@ -269,7 +270,7 @@ export function Settings() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--text-secondary)]">{t('common.loading')}</div>
+        <div className="text-text-secondary">{t('common.loading')}</div>
       </div>
     );
   }
@@ -278,7 +279,7 @@ export function Settings() {
   if (isError || !settings) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--error-text)]">{t('settings.loadError', { defaultValue: 'Failed to load settings' })}</div>
+        <div className="text-error-text">{t('settings.loadError', { defaultValue: 'Failed to load settings' })}</div>
       </div>
     );
   }
@@ -286,20 +287,20 @@ export function Settings() {
   return (
     <div className="space-y-6">
       {/* Tab Navigation */}
-      <div className="flex gap-2 border-b border-[var(--border-default)] pb-2">
+      <div className="flex gap-2 border-b border-border-default pb-2">
         <button
           onClick={() => setActiveTab('profile')}
           className={cn(
             'flex items-center gap-2 px-4 py-2 rounded-t-lg text-sm font-medium transition-colors',
             activeTab === 'profile'
-              ? 'bg-[var(--bg-surface)] text-[var(--text-primary)] border border-b-0 border-[var(--border-default)]'
-              : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)]'
+              ? 'bg-bg-surface text-text-primary border border-b-0 border-border-default'
+              : 'text-text-secondary hover:text-text-primary hover:bg-bg-muted'
           )}
         >
           <User className="w-4 h-4" />
           {t('settings.profileSettings', { defaultValue: 'Profile Settings' })}
           {currentProfile && (
-            <span className="text-xs text-[var(--text-tertiary)]">({currentProfile.name})</span>
+            <span className="text-xs text-text-tertiary">({currentProfile.name})</span>
           )}
         </button>
         <button
@@ -307,8 +308,8 @@ export function Settings() {
           className={cn(
             'flex items-center gap-2 px-4 py-2 rounded-t-lg text-sm font-medium transition-colors',
             activeTab === 'global'
-              ? 'bg-[var(--bg-surface)] text-[var(--text-primary)] border border-b-0 border-[var(--border-default)]'
-              : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-muted)]'
+              ? 'bg-bg-surface text-text-primary border border-b-0 border-border-default'
+              : 'text-text-secondary hover:text-text-primary hover:bg-bg-muted'
           )}
         >
           <Globe className="w-4 h-4" />
@@ -320,7 +321,7 @@ export function Settings() {
       {activeTab === 'profile' && (
         <>
           {!currentProfile ? (
-            <div className="flex items-center justify-center h-64 text-[var(--text-tertiary)]">
+            <div className="flex items-center justify-center h-64 text-text-tertiary">
               {t('settings.loadProfileFirst', { defaultValue: 'Please load a profile to edit its settings.' })}
             </div>
           ) : (
@@ -333,7 +334,7 @@ export function Settings() {
                     <CardDescription>{t('settings.appearanceDescription', { defaultValue: 'Theme and language for this profile.' })}</CardDescription>
                   </div>
                 </CardHeader>
-                <CardBody style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+                <CardBody className="p-6 flex flex-col gap-4">
                   <Select
                     label={t('settings.theme', { defaultValue: 'Theme' })}
                     value={currentThemeId}
@@ -341,14 +342,14 @@ export function Settings() {
                     options={themeOptions}
                     helper={t('settings.themeHelper', { defaultValue: 'Choose your preferred theme appearance.' })}
                   />
-                  <div className="flex items-center" style={{ gap: '12px' }}>
+                  <div className="flex items-center gap-3">
                     <Button variant="outline" onClick={handleInstallTheme} disabled={themeInstalling}>
                       {themeInstalling ? t('common.loading') : t('settings.installTheme', { defaultValue: 'Install Theme' })}
                     </Button>
                   </div>
                   {themeInstallError && (
-                    <div className="p-3 rounded-lg bg-[var(--error-subtle)] border border-[var(--error-border)]">
-                      <p className="text-sm text-[var(--error-text)]">{themeInstallError}</p>
+                    <div className="p-3 rounded-lg bg-error-subtle border border-error-border">
+                      <p className="text-sm text-error-text">{themeInstallError}</p>
                     </div>
                   )}
                   <Select
@@ -370,13 +371,13 @@ export function Settings() {
                     <CardDescription>{t('settings.notificationsSecurityDescription', { defaultValue: 'Notification preferences and data security for this profile.' })}</CardDescription>
                   </div>
                 </CardHeader>
-                <CardBody style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
-                  <div className="flex items-center justify-between" style={{ padding: '8px 0' }}>
+                <CardBody className="p-6 flex flex-col gap-4">
+                  <div className="flex items-center justify-between py-2">
                     <div>
-                      <div className="text-sm font-medium text-[var(--text-primary)]">
+                      <div className="text-sm font-medium text-text-primary">
                         {t('settings.showNotifications')}
                       </div>
-                      <div className="text-xs text-[var(--text-tertiary)]">
+                      <div className="text-xs text-text-tertiary">
                         {t('settings.showNotificationsDescription')}
                       </div>
                     </div>
@@ -385,12 +386,12 @@ export function Settings() {
                       onChange={(checked: boolean) => updateProfileSetting('showNotifications', checked)}
                     />
                   </div>
-                  <div className="flex items-center justify-between" style={{ padding: '8px 0' }}>
+                  <div className="flex items-center justify-between py-2">
                     <div>
-                      <div className="text-sm font-medium text-[var(--text-primary)]">
+                      <div className="text-sm font-medium text-text-primary">
                         {t('settings.encryptStreamKeys')}
                       </div>
-                      <div className="text-xs text-[var(--text-tertiary)]">
+                      <div className="text-xs text-text-tertiary">
                         {t('settings.encryptStreamKeysDescription')}
                       </div>
                     </div>
@@ -418,15 +419,15 @@ export function Settings() {
                     </CardDescription>
                   </div>
                 </CardHeader>
-                <CardBody style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+                <CardBody className="p-6 flex flex-col gap-4">
                   <div className="grid grid-cols-2 gap-6">
                     <div className="space-y-4">
-                      <div className="flex items-center justify-between" style={{ padding: '8px 0' }}>
+                      <div className="flex items-center justify-between py-2">
                         <div>
-                          <div className="text-sm font-medium text-[var(--text-primary)]">
+                          <div className="text-sm font-medium text-text-primary">
                             {t('settings.remoteAccessToggle', { defaultValue: 'Allow remote web access' })}
                           </div>
-                          <div className="text-xs text-[var(--text-tertiary)]">
+                          <div className="text-xs text-text-tertiary">
                             {t('settings.remoteAccessToggleDescription', {
                               defaultValue: 'When off, the API binds to localhost only. Restart required after changes.',
                             })}
@@ -437,12 +438,12 @@ export function Settings() {
                           onChange={(checked: boolean) => updateBackendSetting('remoteEnabled', checked)}
                         />
                       </div>
-                      <div className="flex items-center justify-between" style={{ padding: '8px 0' }}>
+                      <div className="flex items-center justify-between py-2">
                         <div>
-                          <div className="text-sm font-medium text-[var(--text-primary)]">
+                          <div className="text-sm font-medium text-text-primary">
                             {t('settings.remoteAccessUiToggle', { defaultValue: 'Serve web GUI from the host' })}
                           </div>
-                          <div className="text-xs text-[var(--text-tertiary)]">
+                          <div className="text-xs text-text-tertiary">
                             {t('settings.remoteAccessUiToggleDescription', {
                               defaultValue: 'When off, the host will not serve the UI files. Restart required after changes.',
                             })}
@@ -509,12 +510,12 @@ export function Settings() {
                 <CardDescription>{t('settings.ffmpegDescription')}</CardDescription>
               </div>
             </CardHeader>
-            <CardBody style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
-              <div className="flex flex-col" style={{ gap: '6px' }}>
-                <label className="block text-sm font-medium text-[var(--text-primary)]">
+            <CardBody className="p-6 flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="block text-sm font-medium text-text-primary">
                   {t('settings.ffmpegPath')}
                 </label>
-                <div className="flex" style={{ gap: '8px' }}>
+                <div className="flex gap-2">
                   <Input
                     value={ffmpegPath}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -538,7 +539,7 @@ export function Settings() {
                 disabled
                 helper={t('settings.detectedVersion')}
               />
-              <div className="border-t border-[var(--border-muted)]" style={{ paddingTop: '16px' }}>
+              <div className="border-t border-border-muted pt-4">
                 <FFmpegDownloadProgress
                   installedVersion={ffmpegVersion || undefined}
                   autoDownload={settings.autoDownloadFfmpeg}
@@ -559,13 +560,13 @@ export function Settings() {
                 <CardDescription>{t('settings.appBehaviorDescription', { defaultValue: 'System-wide application settings.' })}</CardDescription>
               </div>
             </CardHeader>
-            <CardBody style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
-              <div className="flex items-center justify-between" style={{ padding: '8px 0' }}>
+            <CardBody className="p-6 flex flex-col gap-4">
+              <div className="flex items-center justify-between py-2">
                 <div>
-                  <div className="text-sm font-medium text-[var(--text-primary)]">
+                  <div className="text-sm font-medium text-text-primary">
                     {t('settings.startMinimized')}
                   </div>
-                  <div className="text-xs text-[var(--text-tertiary)]">
+                  <div className="text-xs text-text-tertiary">
                     {t('settings.startMinimizedDescription')}
                   </div>
                 </div>
@@ -597,12 +598,12 @@ export function Settings() {
                 <CardDescription>{t('settings.dataManagementDescription', { defaultValue: 'Export and manage your application data.' })}</CardDescription>
               </div>
             </CardHeader>
-            <CardBody style={{ padding: '24px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
-              <div className="flex flex-col" style={{ gap: '6px' }}>
-                <label className="block text-sm font-medium text-[var(--text-primary)]">
+            <CardBody className="p-6 flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="block text-sm font-medium text-text-primary">
                   {t('settings.profileStorage')}
                 </label>
-                <div className="flex" style={{ gap: '8px' }}>
+                <div className="flex gap-2">
                   <Input value={settings.profileStoragePath} disabled className="flex-1 font-mono text-xs" />
                   <Button variant="outline" onClick={handleOpenProfileStorage}>
                     <FolderOpen className="w-4 h-4" />
@@ -610,7 +611,7 @@ export function Settings() {
                   </Button>
                 </div>
               </div>
-              <div className="flex" style={{ gap: '12px' }}>
+              <div className="flex gap-3">
                 <Button variant="outline" onClick={handleExportData}>
                   <Download className="w-4 h-4" />
                   {t('settings.exportData')}
@@ -632,17 +633,17 @@ export function Settings() {
               </div>
             </CardHeader>
             <CardBody>
-              <div className="text-center" style={{ padding: '16px 0' }}>
-                <div className="flex justify-center" style={{ marginBottom: '16px' }}>
+              <div className="text-center py-4">
+                <div className="flex justify-center mb-4">
                   <Logo size="lg" />
                 </div>
-                <div className="text-sm text-[var(--text-secondary)]" style={{ marginBottom: '4px' }}>
+                <div className="text-sm text-text-secondary mb-1">
                   {t('settings.version')} 0.1.0
                 </div>
-                <div className="text-xs text-[var(--text-tertiary)]" style={{ marginBottom: '24px' }}>
+                <div className="text-xs text-text-tertiary mb-6">
                   {t('settings.tagline')}
                 </div>
-                <div className="flex justify-center" style={{ gap: '12px' }}>
+                <div className="flex justify-center gap-3">
                   <Button
                     variant="ghost"
                     size="sm"
@@ -690,10 +691,10 @@ export function Settings() {
           </>
         }
       >
-        <p className="text-[var(--text-secondary)]">{t('settings.clearConfirm')}</p>
+        <p className="text-text-secondary">{t('settings.clearConfirm')}</p>
         {clearError && (
-          <div className="mt-4 p-3 rounded-lg bg-[var(--error-subtle)] border border-[var(--error-border)]">
-            <p className="text-sm text-[var(--error-text)]">{clearError}</p>
+          <div className="mt-4 p-3 rounded-lg bg-error-subtle border border-error-border">
+            <p className="text-sm text-error-text">{clearError}</p>
           </div>
         )}
       </Modal>

--- a/apps/web/src/views/StreamManager.tsx
+++ b/apps/web/src/views/StreamManager.tsx
@@ -16,6 +16,7 @@ import { toast } from '@/hooks/useToast';
 import type { View } from '@/App';
 import type { OutputGroup as OutputGroupType, StreamTarget } from '@/types/profile';
 import { validateStreamConfig, displayValidationIssues } from '@/lib/streamValidation';
+import { logger } from '@/lib/logger';
 
 interface StreamManagerProps {
   onNavigate: (view: View) => void;
@@ -88,7 +89,7 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
       await startAllGroups(current.outputGroups, incomingUrl);
       toast.success(t('toast.streamStarted'));
     } catch (err) {
-      console.error('[StreamManager] startAllGroups failed:', err);
+      logger.error('[StreamManager] startAllGroups failed:', err);
       toast.error(
         t('toast.startFailed', { error: err instanceof Error ? err.message : String(err) })
       );
@@ -191,7 +192,7 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--text-secondary)]">{t('common.loading')}</div>
+        <div className="text-text-secondary">{t('common.loading')}</div>
       </div>
     );
   }
@@ -199,7 +200,7 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--error-text)]">
+        <div className="text-error-text">
           {t('common.error')}: {error}
         </div>
       </div>
@@ -211,7 +212,7 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
       <Card>
         <CardBody>
           <div className="text-center py-12">
-            <p className="text-[var(--text-secondary)]">{t('streams.selectProfileFirst')}</p>
+            <p className="text-text-secondary">{t('streams.selectProfileFirst')}</p>
           </div>
         </CardBody>
       </Card>
@@ -243,7 +244,7 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
   };
 
   return (
-    <div className="flex flex-col" style={{ gap: '24px' }}>
+    <div className="flex flex-col gap-6">
       {streamError && (
         <Alert variant="error" title={t('streams.streamError')}>
           {streamError}
@@ -292,18 +293,18 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
             <CardDescription>{t('streams.streamControlDescription')}</CardDescription>
           </div>
           {totalBandwidth > 0 && (
-            <div className="flex items-center gap-2 px-3 py-1.5 bg-[var(--bg-muted)] rounded-lg border border-[var(--border-default)]">
-              <Upload className="w-4 h-4 text-[var(--text-tertiary)]" />
+            <div className="flex items-center gap-2 px-3 py-1.5 bg-bg-muted rounded-lg border border-border-default">
+              <Upload className="w-4 h-4 text-text-tertiary" />
               <div className="text-sm">
-                <span className="text-[var(--text-tertiary)]">{t('streams.totalBandwidth')}:</span>
-                <span className="font-semibold text-[var(--text-primary)] ml-1">
+                <span className="text-text-tertiary">{t('streams.totalBandwidth')}:</span>
+                <span className="font-semibold text-text-primary ml-1">
                   {formatTotalBandwidth(totalBandwidth)}
                 </span>
               </div>
             </div>
           )}
         </CardHeader>
-        <CardBody style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        <CardBody className="flex flex-col gap-4">
           {outputGroups.map((group: OutputGroupType) => {
             const stats = groupStats[group.id];
             const isGroupActive = activeGroups.has(group.id);
@@ -324,39 +325,39 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
               >
                 {/* Real-time stats when streaming */}
                 {isGroupActive && stats && (
-                  <div className="grid grid-cols-4 gap-4 p-4 mb-4 bg-[var(--bg-muted)] rounded-lg border border-[var(--border-default)]">
+                  <div className="grid grid-cols-4 gap-4 p-4 mb-4 bg-bg-muted rounded-lg border border-border-default">
                     <div className="text-center">
-                      <div className="flex items-center justify-center gap-1 text-[var(--text-tertiary)] mb-1">
+                      <div className="flex items-center justify-center gap-1 text-text-tertiary mb-1">
                         <Activity className="w-3 h-3" />
                         <span className="text-xs">{t('streams.fps')}</span>
                       </div>
-                      <div className="text-lg font-semibold text-[var(--text-primary)]">
+                      <div className="text-lg font-semibold text-text-primary">
                         {stats.fps.toFixed(1)}
                       </div>
                     </div>
                     <div className="text-center">
-                      <div className="flex items-center justify-center gap-1 text-[var(--text-tertiary)] mb-1">
+                      <div className="flex items-center justify-center gap-1 text-text-tertiary mb-1">
                         <Gauge className="w-3 h-3" />
                         <span className="text-xs">{t('streams.bitrate')}</span>
                       </div>
-                      <div className="text-lg font-semibold text-[var(--text-primary)]">
+                      <div className="text-lg font-semibold text-text-primary">
                         {formatBitrate(stats.bitrate)}
                       </div>
                     </div>
                     <div className="text-center">
-                      <div className="flex items-center justify-center gap-1 text-[var(--text-tertiary)] mb-1">
+                      <div className="flex items-center justify-center gap-1 text-text-tertiary mb-1">
                         <Clock className="w-3 h-3" />
                         <span className="text-xs">{t('streams.uptime')}</span>
                       </div>
-                      <div className="text-lg font-semibold text-[var(--text-primary)]">
+                      <div className="text-lg font-semibold text-text-primary">
                         {formatUptime(stats.uptime)}
                       </div>
                     </div>
                     <div className="text-center">
-                      <div className="text-xs text-[var(--text-tertiary)] mb-1">
+                      <div className="text-xs text-text-tertiary mb-1">
                         {t('streams.speed')}
                       </div>
-                      <div className="text-lg font-semibold text-[var(--text-primary)]">
+                      <div className="text-lg font-semibold text-text-primary">
                         {stats.speed.toFixed(2)}x
                       </div>
                     </div>
@@ -364,22 +365,20 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
                 )}
 
                 <div
-                  className="flex flex-col border-t border-[var(--border-muted)]"
-                  style={{ gap: '12px', paddingTop: '12px' }}
+                  className="flex flex-col border-t border-border-muted gap-3 pt-3"
                 >
                   {group.streamTargets.map((target: StreamTarget) => (
                     <div
                       key={target.id}
-                      className="flex items-center justify-between rounded-lg bg-[var(--bg-surface)] border border-[var(--border-default)]"
-                      style={{ padding: '12px' }}
+                      className="flex items-center justify-between rounded-lg bg-bg-surface border border-border-default p-3"
                     >
-                      <div className="flex items-center" style={{ gap: '12px' }}>
+                      <div className="flex items-center gap-3">
                         <PlatformIcon platform={target.service} size="sm" />
                         <div>
-                          <div className="font-medium text-sm text-[var(--text-primary)]">
+                          <div className="font-medium text-sm text-text-primary">
                             {target.name}
                           </div>
-                          <div className="text-xs text-[var(--text-tertiary)]">{target.url}</div>
+                          <div className="text-xs text-text-tertiary">{target.url}</div>
                         </div>
                       </div>
                       <Toggle
@@ -391,7 +390,7 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
                   ))}
 
                   {group.streamTargets.length === 0 && (
-                    <div className="text-center py-4 text-[var(--text-secondary)]">
+                    <div className="text-center py-4 text-text-secondary">
                       {t('streams.noTargetsInGroup')}
                     </div>
                   )}
@@ -401,8 +400,7 @@ export function StreamManager({ onNavigate }: StreamManagerProps) {
           })}
 
           <div
-            className="flex justify-end border-t border-[var(--border-muted)]"
-            style={{ gap: '12px', paddingTop: '16px' }}
+            className="flex justify-end border-t border-border-muted gap-3 pt-4"
           >
             <Button variant="outline" onClick={() => onNavigate('encoder')}>
               <Settings2 className="w-4 h-4" />

--- a/apps/web/src/views/StreamTargets.tsx
+++ b/apps/web/src/views/StreamTargets.tsx
@@ -73,7 +73,7 @@ export function StreamTargets() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--text-secondary)]">{t('common.loading')}</div>
+        <div className="text-text-secondary">{t('common.loading')}</div>
       </div>
     );
   }
@@ -81,7 +81,7 @@ export function StreamTargets() {
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-[var(--error-text)]">
+        <div className="text-error-text">
           {t('common.error')}: {error}
         </div>
       </div>
@@ -93,7 +93,7 @@ export function StreamTargets() {
       <Card>
         <CardBody>
           <div className="text-center py-12">
-            <p className="text-[var(--text-secondary)]">{t('targets.selectProfileFirst')}</p>
+            <p className="text-text-secondary">{t('targets.selectProfileFirst')}</p>
           </div>
         </CardBody>
       </Card>
@@ -109,28 +109,19 @@ export function StreamTargets() {
       <>
         <Card>
           <CardBody>
-            <div className="text-center" style={{ padding: '48px 0' }}>
+            <div className="text-center py-12">
               <div
-                className="w-16 h-16 mx-auto rounded-full bg-[var(--primary-subtle)] flex items-center justify-center"
-                style={{ marginBottom: '16px' }}
+                className="w-16 h-16 mx-auto rounded-full bg-primary-subtle flex items-center justify-center mb-4"
               >
-                <Plus className="w-8 h-8 text-[var(--primary)]" />
+                <Plus className="w-8 h-8 text-primary" />
               </div>
               <h3
-                className="text-lg font-semibold text-[var(--text-primary)]"
-                style={{ marginBottom: '8px' }}
+                className="text-lg font-semibold text-text-primary mb-2"
               >
                 {t('targets.noStreamTargets')}
               </h3>
               <p
-                className="text-[var(--text-secondary)]"
-                style={{
-                  marginBottom: '24px',
-                  maxWidth: '28rem',
-                  marginLeft: 'auto',
-                  marginRight: 'auto',
-                  textAlign: 'center',
-                }}
+                className="text-text-secondary mb-6 max-w-[28rem] mx-auto text-center"
               >
                 {hasOutputGroups
                   ? t('targets.noStreamTargetsDescription')
@@ -160,15 +151,15 @@ export function StreamTargets() {
       {targets.map((target) => (
         <Card key={target.id}>
           <CardBody>
-            <div className="flex items-start justify-between" style={{ marginBottom: '16px' }}>
-              <div className="flex items-center" style={{ gap: '12px' }}>
+            <div className="flex items-start justify-between mb-4">
+              <div className="flex items-center gap-3">
                 <PlatformIcon platform={target.service} size="lg" />
                 <div>
-                  <h3 className="font-semibold text-[var(--text-primary)]">{target.name}</h3>
-                  <p className="text-sm text-[var(--text-secondary)]">{target.url}</p>
+                  <h3 className="font-semibold text-text-primary">{target.name}</h3>
+                  <p className="text-sm text-text-secondary">{target.url}</p>
                 </div>
               </div>
-              <div className="flex" style={{ gap: '4px' }}>
+              <div className="flex gap-1">
                 <Button
                   variant="ghost"
                   size="icon"
@@ -188,11 +179,11 @@ export function StreamTargets() {
               </div>
             </div>
 
-            <div className="flex flex-col" style={{ gap: '6px' }}>
-              <label className="block text-sm font-medium text-[var(--text-primary)]">
+            <div className="flex flex-col gap-1.5">
+              <label className="block text-sm font-medium text-text-primary">
                 {t('targets.streamKey')}
               </label>
-              <div className="flex" style={{ gap: '8px' }}>
+              <div className="flex gap-2">
                 <Input
                   type={revealedKeys.has(target.id) ? 'text' : 'password'}
                   value={revealedKeys.has(target.id) ? target.streamKey : maskKey(target.streamKey)}
@@ -233,22 +224,20 @@ export function StreamTargets() {
       <Card
         className={`border-2 border-dashed transition-colors ${
           hasOutputGroups
-            ? 'border-[var(--border-default)] hover:border-[var(--primary)] cursor-pointer'
-            : 'border-[var(--border-muted)] opacity-50 cursor-not-allowed'
+            ? 'border-border-default hover:border-primary cursor-pointer'
+            : 'border-border-muted opacity-50 cursor-not-allowed'
         }`}
         onClick={hasOutputGroups ? () => setCreateModalOpen(true) : undefined}
       >
         <CardBody
-          className="flex flex-col items-center justify-center"
-          style={{ padding: '48px 24px' }}
+          className="flex flex-col items-center justify-center py-12 px-6"
         >
           <div
-            className="w-12 h-12 rounded-full bg-[var(--primary-subtle)] flex items-center justify-center"
-            style={{ marginBottom: '12px' }}
+            className="w-12 h-12 rounded-full bg-primary-subtle flex items-center justify-center mb-3"
           >
-            <Plus className="w-6 h-6 text-[var(--primary)]" />
+            <Plus className="w-6 h-6 text-primary" />
           </div>
-          <span className="text-sm font-medium text-[var(--text-secondary)]">
+          <span className="text-sm font-medium text-text-secondary">
             {hasOutputGroups ? t('targets.addNewTarget') : t('targets.createOutputGroupFirst')}
           </span>
         </CardBody>


### PR DESCRIPTION
## Summary
- **Inline styles → Tailwind utilities**: Converted all 78 `style={{}}` attributes to Tailwind classes across 72 files (UI primitives, layout, navigation, views, modals)
- **CSS layer ordering fix**: Moved custom CSS reset (`* { padding: 0; margin: 0 }`) into `@layer base` — unlayered styles were overriding Tailwind utilities, causing all padding/margin to be stripped
- **Theme switch snap-back fix**: Removed `currentThemeId` from the profile-sync `useEffect` dependency array in App.tsx — it was causing a snap-back loop when changing themes in Settings
- **Expanded @theme token map**: Added missing color, status, ring, border, and shadow tokens (61 → full coverage)
- **Logger abstraction**: New `lib/logger.ts` replacing raw `console.*` calls
- **Centralized constants**: New `lib/constants.ts` for delay/timeout/interval values
- **Security hardening**: Added `targetOrigin` to all `postMessage` calls, removed `as any` casts
- **Component optimization**: Extracted static objects/arrays to module scope with `as const`

## Test plan
- [ ] Run `pnpm typecheck` — passes clean
- [ ] Run `pnpm build` — builds successfully
- [ ] Launch desktop app (`pnpm dev:desktop`) — verify dashboard layout renders correctly with proper padding, headers, sidebar spacing
- [ ] Switch themes in Settings → verify no snap-back/flash, immediate clean transition
- [ ] Switch between profiles with different themes → verify theme applies on profile change
- [ ] Test on dark and light themes
- [ ] Verify all views render correctly (Dashboard, Profiles, Stream Manager, Encoder Settings, Output Groups, Stream Targets, Logs, Settings, Integrations, Chat)